### PR TITLE
v3.1.0: macOS DMG fix + .pkg installer + table pagination

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -13,11 +13,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Apple Silicon — native build on M-series runner.
           - platform: 'macos-latest'
-            args: '--target universal-apple-darwin'
+            tauri_target: 'aarch64-apple-darwin'
+            arch_label: 'aarch64'
+            args: '--target aarch64-apple-darwin'
+          # Intel — native build on Intel macOS runner.
+          - platform: 'macos-13'
+            tauri_target: 'x86_64-apple-darwin'
+            arch_label: 'x86_64'
+            args: '--target x86_64-apple-darwin'
           - platform: 'ubuntu-22.04'
+            tauri_target: ''
+            arch_label: ''
             args: ''
           - platform: 'windows-latest'
+            tauri_target: ''
+            arch_label: ''
             args: ''
 
     runs-on: ${{ matrix.platform }}
@@ -35,7 +47,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.tauri_target }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -69,3 +81,39 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+      # Tauri's bundler doesn't ship .pkg natively, so build it ourselves with
+      # pkgbuild (preinstalled on macOS runners). Runs even if the DMG step
+      # above failed, as long as the .app bundle was produced — which it always
+      # is, the failure is at the DMG packaging stage.
+      - name: Build .pkg installer (macOS)
+        if: always() && startsWith(matrix.platform, 'macos') && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          BUNDLE_DIR="webapp/src-tauri/target/${{ matrix.tauri_target }}/release/bundle/macos"
+          if [ ! -d "$BUNDLE_DIR" ]; then
+            echo "::warning::No macOS bundle directory at $BUNDLE_DIR — skipping pkgbuild."
+            exit 0
+          fi
+          cd "$BUNDLE_DIR"
+          APP=$(ls -d *.app 2>/dev/null | head -1 || true)
+          if [ -z "$APP" ]; then
+            echo "::warning::No .app bundle found — skipping pkgbuild."
+            exit 0
+          fi
+          VERSION=$(node -p "require('${{ github.workspace }}/webapp/src-tauri/tauri.conf.json').version")
+          PKG_NAME="$(basename "$APP" .app)_${VERSION}_${{ matrix.arch_label }}.pkg"
+          pkgbuild \
+            --component "$APP" \
+            --identifier com.poli0981.free-games-itchio-webapp \
+            --version "$VERSION" \
+            --install-location /Applications \
+            "$PKG_NAME"
+          ls -la "$PKG_NAME"
+          # Make sure the (draft) release exists so upload doesn't 404.
+          gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --draft --notes "Pending desktop installers."
+          gh release upload "${{ github.ref_name }}" "$PKG_NAME" --repo "${{ github.repository }}" --clobber

--- a/webapp/src/components/data-table/data-table-pagination.tsx
+++ b/webapp/src/components/data-table/data-table-pagination.tsx
@@ -1,0 +1,103 @@
+import type { Table } from '@tanstack/react-table'
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { formatNumber } from '@/lib/utils'
+
+const PAGE_SIZE_OPTIONS = [50, 100, 200, 500] as const
+
+interface DataTablePaginationProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTablePagination<TData>({ table }: DataTablePaginationProps<TData>) {
+  const { pageIndex, pageSize } = table.getState().pagination
+  const filteredRows = table.getFilteredRowModel().rows.length
+  const pageCount = table.getPageCount()
+  const start = filteredRows === 0 ? 0 : pageIndex * pageSize + 1
+  const end = Math.min(filteredRows, (pageIndex + 1) * pageSize)
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-1 py-2">
+      <div className="text-sm text-muted-foreground">
+        {filteredRows === 0
+          ? 'No results'
+          : `Showing ${formatNumber(start)}–${formatNumber(end)} of ${formatNumber(filteredRows)}`}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <p className="text-sm">Rows per page</p>
+          <Select
+            value={`${pageSize}`}
+            onValueChange={(v) => table.setPageSize(Number(v))}
+          >
+            <SelectTrigger className="h-8 w-[80px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PAGE_SIZE_OPTIONS.map((s) => (
+                <SelectItem key={s} value={`${s}`}>
+                  {s}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="text-sm tabular-nums">
+          Page {pageCount === 0 ? 0 : pageIndex + 1} of {pageCount}
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+            aria-label="First page"
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            aria-label="Next page"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => table.setPageIndex(pageCount - 1)}
+            disabled={!table.getCanNextPage()}
+            aria-label="Last page"
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/components/data-table/data-table.tsx
+++ b/webapp/src/components/data-table/data-table.tsx
@@ -2,15 +2,18 @@ import { useMemo, useRef } from 'react'
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type PaginationState,
   type RowSelectionState,
   type SortingState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import { DataTablePagination } from './data-table-pagination'
 import { cn } from '@/lib/utils'
 
 const ROW_HEIGHT = 56
@@ -26,6 +29,8 @@ interface DataTableProps<TData> {
   onSortingChange: (v: SortingState) => void
   rowSelection?: RowSelectionState
   onRowSelectionChange?: (v: RowSelectionState) => void
+  pagination?: PaginationState
+  onPaginationChange?: (v: PaginationState) => void
   globalFilterFn: (row: TData, query: string) => boolean
   rowKey: (row: TData) => string
   getRowId?: (row: TData) => string
@@ -42,14 +47,23 @@ export function DataTable<TData>({
   onSortingChange,
   rowSelection,
   onRowSelectionChange,
+  pagination,
+  onPaginationChange,
   globalFilterFn,
   rowKey,
   getRowId,
 }: DataTableProps<TData>) {
+  const enablePagination = !!pagination && !!onPaginationChange
   const table = useReactTable({
     data,
     columns,
-    state: { columnFilters, sorting, globalFilter, rowSelection: rowSelection ?? {} },
+    state: {
+      columnFilters,
+      sorting,
+      globalFilter,
+      rowSelection: rowSelection ?? {},
+      ...(enablePagination ? { pagination } : {}),
+    },
     onGlobalFilterChange: (updater) =>
       onGlobalFilterChange(typeof updater === 'function' ? updater(globalFilter) : updater),
     onColumnFiltersChange: (updater) =>
@@ -64,11 +78,18 @@ export function DataTable<TData>({
             typeof updater === 'function' ? updater(rowSelection ?? {}) : updater,
           )
       : undefined,
+    onPaginationChange: enablePagination
+      ? (updater) =>
+          onPaginationChange(
+            typeof updater === 'function' ? updater(pagination!) : updater,
+          )
+      : undefined,
     getRowId: getRowId,
     enableRowSelection: !!onRowSelectionChange,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    ...(enablePagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
     globalFilterFn: (row, _columnId, filterValue) =>
       globalFilterFn(row.original as TData, String(filterValue ?? '')),
     enableMultiSort: true,
@@ -90,8 +111,9 @@ export function DataTable<TData>({
   const headerGroups = useMemo(() => table.getHeaderGroups(), [table])
 
   return (
-    <div className="rounded-md border bg-card">
-      <div ref={parentRef} className="relative max-h-[calc(100vh-220px)] overflow-auto">
+    <div className="space-y-2">
+      <div className="rounded-md border bg-card">
+      <div ref={parentRef} className="relative max-h-[calc(100vh-280px)] overflow-auto">
         <table className="w-full text-sm">
           <thead className="sticky top-0 z-10 bg-card shadow-[inset_0_-1px_0_hsl(var(--border))]">
             {headerGroups.map((hg) => (
@@ -155,6 +177,8 @@ export function DataTable<TData>({
           </tbody>
         </table>
       </div>
+      </div>
+      {enablePagination && <DataTablePagination table={table} />}
     </div>
   )
 }

--- a/webapp/src/routes/games.tsx
+++ b/webapp/src/routes/games.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react'
 import {
   type ColumnFiltersState,
+  type PaginationState,
   type RowSelectionState,
   type SortingState,
   getCoreRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
@@ -42,6 +44,7 @@ export default function Games() {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [sorting, setSorting] = useState<SortingState>([{ id: 'name', desc: false }])
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+  const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 100 })
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -74,16 +77,18 @@ export default function Games() {
   const tableForToolbar = useReactTable({
     data,
     columns: gameColumns,
-    state: { columnFilters, sorting, globalFilter, rowSelection },
+    state: { columnFilters, sorting, globalFilter, rowSelection, pagination },
     onColumnFiltersChange: setColumnFilters,
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
     onRowSelectionChange: setRowSelection,
+    onPaginationChange: setPagination,
     enableRowSelection: true,
     getRowId: (g) => g.url,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     globalFilterFn: (row, _id, value) => gameSearch(row.original, String(value ?? '')),
     enableMultiSort: true,
   })
@@ -175,6 +180,8 @@ export default function Games() {
         onSortingChange={setSorting}
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}
+        pagination={pagination}
+        onPaginationChange={setPagination}
         globalFilterFn={gameSearch}
         rowKey={(g) => g.url}
         getRowId={(g) => g.url}


### PR DESCRIPTION
## Summary

Fixes the macOS DMG bundling that failed in v3.0.1's release build, ships a real `.pkg` installer alongside DMG, and adds a pagination footer with page-size selector to the Games table.

## macOS DMG bundling

\`\`\`
Bundling Itch.io Free Games DB_0.1.0_universal.dmg
Running bundle_dmg.sh
failed to bundle project error running bundle_dmg.sh
\`\`\`

`universal-apple-darwin` (lipo'd ARM + Intel) is a known fragility around `bundle_dmg.sh` + AppleScript + `hdiutil` in headless CI. Switched the matrix to two native targets so each DMG packages a single-arch binary instead of a universal lipo:

| Runner | Tauri target | Output |
|---|---|---|
| `macos-latest` (Apple Silicon) | `aarch64-apple-darwin` | DMG + .pkg |
| `macos-13` (Intel) | `x86_64-apple-darwin` | DMG + .pkg |

`fail-fast: false` already, so a flake on one arch doesn't kill the other.

## `.pkg` installer (requested by [@poli0981](https://github.com/poli0981))

Tauri's bundler doesn't emit `.pkg`. Added a follow-on step that runs `pkgbuild` (preinstalled on macOS runners) against the `.app` produced by `tauri-action` and uploads to the same draft release:

\`\`\`bash
pkgbuild \
  --component "$APP" \
  --identifier com.poli0981.free-games-itchio-webapp \
  --version "$VERSION" \
  --install-location /Applications \
  "$PKG_NAME"
gh release upload "$TAG" "$PKG_NAME" --clobber
\`\`\`

Gated on `if: always()` — pkgbuild only needs the `.app` (built before DMG packaging), so even if a future Tauri/runner regression breaks DMG again, `.pkg` still ships.

Output: `{AppName}_{version}_{aarch64|x86_64}.pkg`.

## Games table pagination

New `DataTablePagination` footer below the table:

- **Rows per page**: 50 / 100 / 200 / 500 (default 100)
- **Page X of Y** counter
- **First / Prev / Next / Last** buttons
- **\"Showing M-N of T\"** range label

Pagination state lifted into the Games route so toolbar counts (\"filtered of total\") and bulk-action selection survive filter/sort/page changes. Virtualization is still inside each page, so a 500-row page doesn't blow render perf.

## Test plan

- [ ] Push tag → `release_desktop.yml` succeeds on all 4 jobs (or at minimum `.pkg` lands on macOS even if DMG flakes)
- [ ] Release page shows: `.app.tar.gz` × 2, `.dmg` × 2, `.pkg` × 2, `.msi` / `.exe`, `.deb` / `.AppImage`
- [ ] Games page: switch page size 50/100/200/500, Prev/Next buttons disable correctly at boundaries
- [ ] Filter / sort while on page 3 → page index resets sensibly (TanStack default behavior)
- [ ] Selection across pages: select rows on page 1 → go to page 2 → bulk Edit shows all selected (covered by `getRowId: (g) => g.url`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)