### PR TITLE
fix(ci): cross-compile macOS x86_64 from Apple Silicon (macos-13 retired)

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -18,8 +18,11 @@ jobs:
             tauri_target: 'aarch64-apple-darwin'
             arch_label: 'aarch64'
             args: '--target aarch64-apple-darwin'
-          # Intel — native build on Intel macOS runner.
-          - platform: 'macos-13'
+          # Intel — cross-compile from Apple Silicon runner because GitHub
+          # retired `macos-13` from free hosted runners (jobs sit in 'queued'
+          # forever and get auto-cancelled). Xcode CLI tools on `macos-latest`
+          # ship the x86_64 SDK and rustup adds the target below.
+          - platform: 'macos-latest'
             tauri_target: 'x86_64-apple-darwin'
             arch_label: 'x86_64'
             args: '--target x86_64-apple-darwin'


### PR DESCRIPTION
## Summary

The \`macos-13\` job in v3.1.0's release run sat in \`queued\` forever and GitHub auto-cancelled it (\`runner_name\` was \`null\` in the run output):

\`\`\`json
{
  \"name\": \"build-tauri (macos-13, x86_64-apple-darwin, ...)\",
  \"status\": \"completed\",
  \"conclusion\": \"cancelled\",
  \"runner_name\": null
}
\`\`\`

GitHub **retired \`macos-13\` from free-tier hosted runners** in late 2024 — jobs requesting that label never get picked up and eventually time out.

## Fix

Run both macOS jobs on \`macos-latest\` (Apple Silicon). The Intel job cross-compiles to \`x86_64-apple-darwin\`:

| Runner | Target | Build |
|---|---|---|
| \`macos-latest\` | \`aarch64-apple-darwin\` | native |
| \`macos-latest\` | \`x86_64-apple-darwin\` | cross-compile |

\`dtolnay/rust-toolchain@stable\` already runs \`rustup target add \${{ matrix.tauri_target }}\`, and Xcode CLI tools on \`macos-latest\` carry both SDKs, so no extra setup is needed.

\`bundle_dmg.sh\` packages a single-arch x86_64 binary on an aarch64 host — it stages the binary into a disk image, doesn't execute it, so this doesn't reintroduce the \`universal-apple-darwin\` failure that v3.1.0 fixed by going per-arch.

## Test plan

- [ ] Tag \`v3.1.1\` → \`release_desktop.yml\` runs all 4 jobs
- [ ] Both macOS jobs pick up runners (\`runner_name\` non-null)
- [ ] x86_64 job's DMG and PKG land on the release alongside aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)