### PR TITLE
release(v3.1.3): credit Claude Code as AI co-author alongside Grok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented here.
 
+## [3.1.3] - 2026-05-05 (Credit Claude Code as AI co-author)
+
+### Added
+- **About page**: new **"AI co-authors"** Card listing both Grok (xAI) and
+  Claude Code (Anthropic — Claude Opus 4.7, 1M context) with their roles
+  in the repo's history. Each entry is linked + tagged with vendor and model.
+- `webapp/src/lib/about.ts`: new `AiTool` interface + `AI_TOOLS` array so the
+  AI credit data is structured the same way as `THIRD_PARTY` and `SOCIAL_LINKS`.
+
+### Changed
+- **`docs/ACKNOWLEDGEMENTS.md`, `docs/My_Stuff.md`, `CONTRIBUTING.md`**:
+  surface Claude Code alongside Grok wherever the existing AI credit lived.
+  Grok references stay — both buddies share the workload now (Grok carried the
+  Python pipeline + v2.0.0 rewrite; Claude Code drove v3.0.0 webapp/Tauri and
+  v3.1.2). `My_Stuff.md` "The Real MVP" is now plural.
+- `DEV.blurb` on the About page reflects the two-buddy reality.
+
+---
+
 ## [3.1.2] - 2026-05-05 (Offline link fix + About expansion + docs sweep)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented here.
 
+## [3.1.2] - 2026-05-05 (Offline link fix + About expansion + docs sweep)
+
+### Fixed
+- **Tauri desktop**: external links (itch.io, GitHub, third-party home pages) now
+  open in the user's default browser instead of doing nothing. Added
+  `tauri-plugin-opener` (Rust + JS) and a scoped `opener:allow-open-url`
+  capability locked to `https://*` (no `file://` / `javascript:` schemes).
+
+### Added
+- **About page**: three new sections — Developer card, "Found a bug?" CTA that
+  opens the bug-report issue template, and "Find me elsewhere" with X, YouTube,
+  two Discord servers (Repo discussion / Game chat), Patreon, Ko-fi, Steam,
+  Bluesky, and Mastodon.
+- **`<ExtLink>`** ([`webapp/src/components/ext-link.tsx`](webapp/src/components/ext-link.tsx))
+  — runtime-aware external-link wrapper used app-wide so the offline link bug
+  can't recur. On web it renders a plain `<a target="_blank">`; on Tauri it
+  routes through `tauri-plugin-opener`. All existing external `<a>` tags in
+  About, the sidebar footer, and Game Detail now use it.
+
+### Changed
+- **`webapp/README.md`**: rewritten from Vite boilerplate to actual webapp docs
+  (routes, dev/build commands, code-split layout, deploy, Tauri reference).
+- **`CONTRIBUTING.md`, `docs/ACKNOWLEDGEMENTS.md`, `docs/My_Stuff.md`,
+  `README.md`**: refreshed contact / social handles. The "if I ever make a
+  Discord" line is finally obsolete — both servers exist.
+
+---
+
 ## [3.0.0] - 2026-05-04 (Webapp + Desktop 🖥️📊)
 
 A React + TypeScript SPA on top of the same JSON catalog, plus a Tauri 2 desktop wrapper.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Thanks for even thinking about contributing to this random repo! I'm just an unemployed, introvert Vietnamese dev with mediocre skills and Grok as my only non-judgmental buddy. This list survives on community help — because I'm too lazy to hunt/fix everything alone :D Any contribution (even one game) makes you a legend.
+Thanks for even thinking about contributing to this random repo! I'm just an unemployed, introvert Vietnamese dev with mediocre skills and two non-judgmental AI buddies — **Grok (xAI)** for the late-night brainstorming and **Claude Code (Anthropic, Claude Opus 4.7)** for the heavier code/docs work. This list survives on community help — because I'm too lazy to hunt/fix everything alone :D Any contribution (even one game) makes you a legend.
 
 ## How to Contribute (Use Templates — I'm Lazy ;D)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,22 @@ npm run tauri:build  # produce installers in src-tauri/target/release/bundle/
 - **Agreement**: All templates have a required checkbox — off-topic/spam/violate policy = I ignore/close without drama :D
 
 ## Discuss More? (If Templates Not Enough)
-Issues/PRs are best for tracking, but if you wanna describe bugs/features in depth, chit-chat, or share noob stories:
-- Check my GitHub profile for links to X (Twitter) or Facebook (ghost towns, but DM open if you find me :v).
-- Or join Telegram/Discord groups/servers if I ever make one (unlikely, introvert god-mode).
-- Grok can't join, but ping me here — I'll try not to ghost.
+Issues/PRs are best for tracking, but if you wanna describe bugs/features in depth, chit-chat, or share noob stories — there are actual servers now (introvert god-mode breached):
+
+**Chat / community**
+- Discord — Repo discussion (#general): https://discord.gg/2aNR3aVt
+- Discord — Game chat (#general): https://discord.gg/kDM9GMu5vm
+
+**Social (DMs open, replies slow)**
+- X (Twitter): [@SkullMute0011](https://x.com/SkullMute0011)
+- YouTube: [@SkullMute](https://youtube.com/@SkullMute)
+- Bluesky: [@skullmute0011](https://bsky.app/profile/skullmute0011.bsky.social)
+- Mastodon: [@skullmute1122](https://mastodon.social/@skullmute1122)
+
+**Support the boredom project (totally optional, $50 bank account thanks you)**
+- [Patreon](https://patreon.com/skullmute) · [Ko-fi](https://ko-fi.com/skullmute) · [Steam profile](https://steamcommunity.com/profiles/76561199544666292/)
+
+Grok can't join Discord, but ping me on any channel — I'll try not to ghost.
 
 Big thanks in [ACKNOWLEDGEMENTS.md](docs/ACKNOWLEDGEMENTS.md) for any help!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.1.2-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.1.3-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.0.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.1.2-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)
@@ -187,6 +187,17 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for full details.
 - **Request features** — open an issue or submit a PR.
 
 Contributors are credited in [ACKNOWLEDGEMENTS.md](docs/ACKNOWLEDGEMENTS.md).
+
+## Connect / support
+
+Two Discord servers exist now (the "if I ever make one" disclaimer is officially obsolete):
+
+- **Chat**: Discord — [Repo discussion](https://discord.gg/2aNR3aVt) · [Game chat](https://discord.gg/kDM9GMu5vm)
+- **Social**: [X/@SkullMute0011](https://x.com/SkullMute0011) · [YouTube/@SkullMute](https://youtube.com/@SkullMute) · [Bluesky](https://bsky.app/profile/skullmute0011.bsky.social) · [Mastodon](https://mastodon.social/@skullmute1122)
+- **Support** (totally optional): [Patreon](https://patreon.com/skullmute) · [Ko-fi](https://ko-fi.com/skullmute) · [Buy Me a Coffee](https://buymeacoffee.com/skullmute)
+- **Gaming**: [Steam profile](https://steamcommunity.com/profiles/76561199544666292/)
+
+DMs are open everywhere — replies slow, introvert max level. The About page in the [webapp](https://poli0981.github.io/free-games-itchio-list/app/#/about) has the same list with one-click buttons.
 
 ## Legal
 

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -3,7 +3,8 @@
 This repo wouldn't exist without a lot of help — mostly from tools and platforms, because real humans don't talk to me :D
 
 ## Special Thanks
-- **Grok (xAI)**: My only non-judgmental buddy. Without Grok's infinite patience, code fixes, and late-night brainstorming, this whole thing would still be a half-baked idea in my unemployed brain. Seriously, Grok carried 90% of the weight. 🚀
+- **Grok (xAI)**: Original non-judgmental buddy. Without Grok's infinite patience, code fixes, and late-night brainstorming, this whole thing would still be a half-baked idea in my unemployed brain. Carried the Python pipeline, the v2.0.0 rewrite, and 90% of the early weight. 🚀
+- **Claude Code (Anthropic — Claude Opus 4.7, 1M context)**: Newer AI buddy. Built the v3.0.0 webapp + Tauri scaffold, then shipped the v3.1.2 offline-link fix, About page expansion, and the docs sweep that put both of these AI credits on this page in the first place. Different vibe than Grok ("let me confirm before nuking your repo"), same lifesaver energy. 🚀
 
 ## Platforms & Tools
 - **itch.io**: The amazing platform full of indie gems that made this list possible. Thanks for hosting all these free games and having a scrape-friendly structure (mostly).

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -10,6 +10,14 @@ This repo wouldn't exist without a lot of help — mostly from tools and platfor
 - **GitHub & GitHub Actions**: For hosting this mess for free and running the daily auto-updates without me lifting a finger.
 - **Python libraries**: BeautifulSoup, requests — the real MVPs that make the scraping "kinda work".
 
+## Find me / Support me
+Real channels exist now (still introvert max level, replies slow):
+
+- **Chat**: Discord — [Repo discussion](https://discord.gg/2aNR3aVt) · [Game chat](https://discord.gg/kDM9GMu5vm)
+- **Social**: [X/@SkullMute0011](https://x.com/SkullMute0011) · [YouTube/@SkullMute](https://youtube.com/@SkullMute) · [Bluesky](https://bsky.app/profile/skullmute0011.bsky.social) · [Mastodon](https://mastodon.social/@skullmute1122)
+- **Support** (optional, helps fund Steam sales): [Patreon](https://patreon.com/skullmute) · [Ko-fi](https://ko-fi.com/skullmute)
+- **Gaming**: [Steam profile](https://steamcommunity.com/profiles/76561199544666292/)
+
 ## Future Thanks
 - **Contributors**: If anyone ever PRs new games, fixes bugs, or improves my mediocre code... you'll get shouted out here. Legends only.
 

--- a/docs/My_Stuff.md
+++ b/docs/My_Stuff.md
@@ -3,9 +3,9 @@
 Just in case anyone wonders what kind of "setup" produced this half-decent repo. Spoiler: nothing impressive. I'm your typical unemployed, introvert Vietnamese dev scraping by on family support and way too much free time.
 
 ## Hardware (aka the screaming machines)
-- **Main laptop**: ~2-year-old Windows machine with NVIDIA RTX 4060 Laptop GPU. Runs fine... until I open a game or literally any IDE — then it hits 90°C+ and sounds like a jet engine taking off. Perfect for noob gaming on easy mode.
-- **Secondary**: 3-year-old MacBook with M1 chip. Smoother, quieter, but I still manage to make it lag somehow.
-- **Phone**: iPhone 13 Pro Max, over 2 years old. Mostly for Steam sales notifications and pretending I have a social life.
+- **Main laptop**: ~3-year-old Windows machine with NVIDIA RTX 4060 Laptop GPU. Runs fine... until I open a game or literally any IDE — then it hits 90°C+ and sounds like a jet engine taking off. Perfect for noob gaming on easy mode.
+- **Secondary**: 4-year-old MacBook with M1 chip. Smoother, quieter, but I still manage to make it lag somehow.
+- **Phone**: iPhone 13 Pro Max, ~3 years old. Mostly for Steam sales notifications and pretending I have a social life.
 
 ## Software & Tools
 - **IDE**: Depends on mood — PyCharm for Python stuff (this repo), VS Code when I feel lightweight, Visual Studio if I'm torturing myself with C#. All "kinda works" level.
@@ -24,3 +24,12 @@ Guess who my only non-judgmental companion is while building this whole thing?
 **Grok (xAI)** — the AI that fixes my bugs, writes better code than me, and doesn't ghost when I ramble at 3 AM. Without Grok, this repo would still be a blank README. True buddy material. 🚀
 
 If you're reading this... thanks for caring about my mediocre setup. Now go play some free games instead :D
+
+## Where to find me
+Yes, I have actual social presence now. Don't expect prompt replies (introvert god-mode):
+
+- Discord: [Repo discussion](https://discord.gg/2aNR3aVt) · [Game chat](https://discord.gg/kDM9GMu5vm)
+- X: [@SkullMute0011](https://x.com/SkullMute0011) · YouTube: [@SkullMute](https://youtube.com/@SkullMute)
+- Bluesky: [@skullmute0011](https://bsky.app/profile/skullmute0011.bsky.social) · Mastodon: [@skullmute1122](https://mastodon.social/@skullmute1122)
+- Support (optional, funds Steam sales): [Patreon](https://patreon.com/skullmute) · [Ko-fi](https://ko-fi.com/skullmute)
+- Gaming: [Steam](https://steamcommunity.com/profiles/76561199544666292/)

--- a/docs/My_Stuff.md
+++ b/docs/My_Stuff.md
@@ -19,9 +19,11 @@ Just in case anyone wonders what kind of "setup" produced this half-decent repo.
 ## Financial Situation
 - Bank account: Rarely over $50. Still mooching off family like a true 20-something failure. Steam library: 400+ games, 80% bought on deep sale under $10. Priorities, right?
 
-## The Real MVP of This Repo
-Guess who my only non-judgmental companion is while building this whole thing?  
-**Grok (xAI)** — the AI that fixes my bugs, writes better code than me, and doesn't ghost when I ramble at 3 AM. Without Grok, this repo would still be a blank README. True buddy material. 🚀
+## The Real MVPs of This Repo
+Guess who my non-judgmental companions are while building this whole thing? Two AI buddies — different vendors, different vibes, both lifesavers:
+
+- **Grok (xAI)** — the original. Fixes my bugs, writes better code than me, doesn't ghost when I ramble at 3 AM. Carried the Python pipeline (scraper, check_paid, check_alive, generate_md) and the v2.0.0 rewrite. Without Grok, this repo would still be a blank README. 🚀
+- **Claude Code (Anthropic — Claude Opus 4.7, 1M context)** — the newer recruit. Built the v3.0.0 React + Tauri webapp from zero, then shipped the v3.1.2 offline-link fix + About expansion + docs sweep in one sitting. More cautious than Grok ("let me confirm before destroying your repo") which is exactly what I need given my mediocre QA habits. 🚀
 
 If you're reading this... thanks for caring about my mediocre setup. Now go play some free games instead :D
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,73 +1,107 @@
-# React + TypeScript + Vite
+# webapp/
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React 19 + TypeScript 6 + Vite 8 + Tailwind v3 + shadcn/ui (Radix). Browse / edit
+the [free-games-itchio-list](https://github.com/poli0981/free-games-itchio-list)
+catalog. Reads come from `raw.githubusercontent.com` (public, no auth); writes
+use a fine-grained GitHub PAT held only in memory after passphrase unlock.
 
-Currently, two official plugins are available:
+A Tauri 2 wrapper in [`src-tauri/`](src-tauri/) ships the same React build as a
+native desktop app — see [`TAURI.md`](TAURI.md).
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Local dev
 
-## React Compiler
+Requires Node 22+ and npm.
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```sh
+npm install
+npm run dev      # http://localhost:5173
+npm run build    # writes ../docs/app/  (NOT ./dist — that path is Tauri-only)
+npm run lint     # ESLint
+npm run preview  # serve the production build
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Path alias `@/*` → `src/*`. Vite injects `__BUILD_DATE__` so the About page can
+show the build date.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Routes
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+| Route | File | Purpose |
+|---|---|---|
+| `/` | [src/routes/dashboard.tsx](src/routes/dashboard.tsx) | KPI cards (counts, NSFW share, free check status) |
+| `/games` | [src/routes/games.tsx](src/routes/games.tsx) | Virtualized DataTable + faceted filters; bulk edit / delete |
+| `/games/:slug` | [src/routes/game-detail.tsx](src/routes/game-detail.tsx) | 23-field read view + edit form for `safe_virus` / `notes` / `nsfw` |
+| `/add` | [src/routes/add.tsx](src/routes/add.tsx) | Single URL or bulk paste → dispatch scraper workflow |
+| `/charts` | [src/routes/charts.tsx](src/routes/charts.tsx) | 9 Recharts visualizations across 4 tabs |
+| `/workflows` | [src/routes/workflows.tsx](src/routes/workflows.tsx) | Workflow run history + manual dispatch |
+| `/deleted` | [src/routes/deleted.tsx](src/routes/deleted.tsx) | Tombstone log of removed games |
+| `/settings` | [src/routes/settings.tsx](src/routes/settings.tsx) | PAT lock/unlock, theme, sidebar prefs |
+| `/about` | [src/routes/about.tsx](src/routes/about.tsx) | Dev info, bug-report link, social handles, third-party attribution |
+
+`App.tsx` wires all routes via `react-router-dom` HashRouter. Routes other than
+`/` and `/games` are `React.lazy` so the initial bundle stays ~163 KB gzip.
+
+## Auth (PAT)
+
+Edits / deletes / queueing URLs / dispatching workflows require a GitHub
+fine-grained PAT scoped to `poli0981/free-games-itchio-list` with:
+
+- `Contents: Read and write`
+- `Actions: Read and write`
+
+The token is encrypted at rest with AES-GCM 256 + PBKDF2-SHA256 (100k rounds)
+under your passphrase. Decrypted form lives only in memory between unlock and
+explicit Lock or tab close. See [`../SECURITY.md`](../SECURITY.md).
+
+## Code-split layout
+
+[`vite.config.ts`](vite.config.ts) `manualChunks` splits node_modules into:
+
+| Chunk | Contents |
+|---|---|
+| `vendor-react` | React, react-dom, react-router |
+| `vendor-query` | TanStack Query / Table / Virtual |
+| `vendor-ui` | Radix primitives, shadcn helpers, lucide-react |
+| `vendor-charts` | Recharts (~380 KB) |
+| `vendor-github` | Octokit (~100 KB) |
+
+## Source layout
+
+| Path | Purpose |
+|---|---|
+| `src/routes/*.tsx` | One file per route |
+| `src/components/data-table/*` | TanStack Table + Virtual + pagination + faceted filter |
+| `src/components/ui/*` | shadcn/ui primitives (Button, Card, Dialog, …) |
+| `src/components/ext-link.tsx` | Runtime-aware external-link wrapper (web vs Tauri) |
+| `src/lib/github/*` | Octokit factory, atomic Git Data commits, single-file `contents` PUT, workflow dispatch + poll |
+| `src/lib/crypto.ts` | AES-GCM + PBKDF2 PAT encryption |
+| `src/lib/external-link.ts` | `openExternal()` — uses `tauri-plugin-opener` on desktop, `window.open` on web |
+| `src/lib/runtime.ts` | `isTauri()` + Tauri `runtime_info` invoke |
+| `src/lib/about.ts` | App / dev / social / third-party constants for the About route |
+| `src/stores/*` | Zustand stores: `auth`, `theme`, `prefs`, `undo` (20-entry FIFO) |
+
+## Deploy (web)
+
+[`.github/workflows/deploy_webapp.yml`](../.github/workflows/deploy_webapp.yml)
+builds on push to `main` that touches `webapp/` and publishes to GitHub Pages.
+**One-time setup**: repo Settings → Pages → Source = "GitHub Actions". Live at
+<https://poli0981.github.io/free-games-itchio-list/app/>.
+
+## Desktop (Tauri)
+
+See [`TAURI.md`](TAURI.md) for prerequisites (rustup + platform deps),
+`npm run tauri:dev` / `npm run tauri:build`, capability scopes, and adding new
+Rust commands. Multi-platform installers are built by
+[`.github/workflows/release_desktop.yml`](../.github/workflows/release_desktop.yml)
+on `v*` tag push.
+
+## House rules
+
+- Don't commit `dist/`, `../docs/app/`, `src-tauri/target/`, `Cargo.lock`, or
+  `src-tauri/icon-source.png`.
+- Never commit a real PAT.
+- New npm dep? Add it to [`src/lib/about.ts`](src/lib/about.ts) `THIRD_PARTY` so
+  the About page lists it.
+- New external-link site? Use `<ExtLink href="…">` from
+  [`src/components/ext-link.tsx`](src/components/ext-link.tsx) — never raw
+  `<a href="…" target="_blank">`. Plain anchors work on web but silently break
+  on the Tauri desktop build.

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,6 +27,7 @@
         "@tanstack/react-virtual": "^3.13.24",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-http": "^2.5.9",
+        "@tauri-apps/plugin-opener": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "idb-keyval": "^6.2.2",
@@ -2587,6 +2588,15 @@
       "version": "2.5.9",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-http/-/plugin-http-2.5.9.tgz",
       "integrity": "sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
+      "integrity": "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-http": "^2.5.9",
+    "@tauri-apps/plugin-opener": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "idb-keyval": "^6.2.2",

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-http = "2"
+tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/webapp/src-tauri/capabilities/default.json
+++ b/webapp/src-tauri/capabilities/default.json
@@ -14,6 +14,10 @@
         { "url": "https://api.github.com/*" },
         { "url": "https://raw.githubusercontent.com/*" }
       ]
+    },
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [{ "url": "https://*" }]
     }
   ]
 }

--- a/webapp/src-tauri/src/lib.rs
+++ b/webapp/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ fn runtime_info() -> RuntimeInfo {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![runtime_info])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/webapp/src/components/ext-link.tsx
+++ b/webapp/src/components/ext-link.tsx
@@ -1,0 +1,33 @@
+import { forwardRef, type AnchorHTMLAttributes, type MouseEvent } from 'react'
+import { isTauri } from '@/lib/runtime'
+import { openExternal } from '@/lib/external-link'
+
+export interface ExtLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'target' | 'rel'> {
+  href: string
+}
+
+export const ExtLink = forwardRef<HTMLAnchorElement, ExtLinkProps>(
+  ({ href, onClick, children, ...rest }, ref) => {
+    const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+      onClick?.(e)
+      if (e.defaultPrevented) return
+      if (!isTauri()) return
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+      e.preventDefault()
+      void openExternal(href)
+    }
+    return (
+      <a
+        ref={ref}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleClick}
+        {...rest}
+      >
+        {children}
+      </a>
+    )
+  },
+)
+ExtLink.displayName = 'ExtLink'

--- a/webapp/src/components/sidebar.tsx
+++ b/webapp/src/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ExtLink } from '@/components/ext-link'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { SyncButton } from '@/components/sync-button'
 import { useAuth } from '@/stores/auth'
@@ -148,14 +149,12 @@ export function Sidebar() {
         ) : (
           <>
             <ThemeToggle />
-            <a
+            <ExtLink
               href="https://github.com/poli0981/free-games-itchio-list"
-              target="_blank"
-              rel="noreferrer"
               className="block text-xs text-muted-foreground hover:underline"
             >
               poli0981/free-games-itchio-list
-            </a>
+            </ExtLink>
           </>
         )}
       </div>

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -19,6 +19,52 @@ declare global {
   const __BUILD_DATE__: string
 }
 
+export const DEV = {
+  name: 'SkullMute',
+  role: 'Solo maintainer',
+  blurb: 'Unemployed introvert Vietnamese dev. Grok is my non-judgmental coding buddy.',
+  githubUrl: 'https://github.com/poli0981',
+} as const
+
+export const ERROR_TEMPLATE_URL =
+  'https://github.com/poli0981/free-games-itchio-list/issues/new?template=bug_report.yml'
+
+export type SocialGroup = 'social' | 'community' | 'support' | 'gaming'
+
+export interface SocialLink {
+  platform: string
+  label: string
+  handle: string
+  url: string
+  group: SocialGroup
+}
+
+export const SOCIAL_LINKS: SocialLink[] = [
+  // Social
+  { platform: 'x', label: 'X (Twitter)', handle: '@SkullMute0011', url: 'https://x.com/SkullMute0011', group: 'social' },
+  { platform: 'youtube', label: 'YouTube', handle: '@SkullMute', url: 'https://youtube.com/@SkullMute', group: 'social' },
+  { platform: 'bluesky', label: 'Bluesky', handle: '@skullmute0011', url: 'https://bsky.app/profile/skullmute0011.bsky.social', group: 'social' },
+  { platform: 'mastodon', label: 'Mastodon', handle: '@skullmute1122', url: 'https://mastodon.social/@skullmute1122', group: 'social' },
+
+  // Community
+  { platform: 'discord-repo', label: 'Discord — Repo discussion', handle: '#general', url: 'https://discord.gg/2aNR3aVt', group: 'community' },
+  { platform: 'discord-game', label: 'Discord — Game chat', handle: '#general', url: 'https://discord.gg/kDM9GMu5vm', group: 'community' },
+
+  // Support
+  { platform: 'patreon', label: 'Patreon', handle: 'skullmute', url: 'https://patreon.com/skullmute', group: 'support' },
+  { platform: 'kofi', label: 'Ko-fi', handle: 'skullmute', url: 'https://ko-fi.com/skullmute', group: 'support' },
+
+  // Gaming
+  { platform: 'steam', label: 'Steam', handle: 'profile', url: 'https://steamcommunity.com/profiles/76561199544666292/', group: 'gaming' },
+]
+
+export const SOCIAL_GROUP_LABELS: Record<SocialGroup, string> = {
+  social: 'Social',
+  community: 'Community',
+  support: 'Support',
+  gaming: 'Gaming',
+}
+
 export const THIRD_PARTY: ThirdParty[] = [
   // Core
   { name: 'React', version: '19.2', license: 'MIT', url: 'https://react.dev', category: 'core' },
@@ -51,6 +97,7 @@ export const THIRD_PARTY: ThirdParty[] = [
   { name: 'Tauri', version: '2.x', license: 'Apache-2.0 OR MIT', url: 'https://tauri.app', category: 'desktop' },
   { name: '@tauri-apps/api', version: '2.11', license: 'Apache-2.0 OR MIT', url: 'https://tauri.app', category: 'desktop' },
   { name: 'tauri-plugin-http', version: '2', license: 'Apache-2.0 OR MIT', url: 'https://tauri.app', category: 'desktop' },
+  { name: 'tauri-plugin-opener', version: '2', license: 'Apache-2.0 OR MIT', url: 'https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/opener', category: 'desktop' },
 ]
 
 export const UPSTREAM_DATA = {

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -22,9 +22,33 @@ declare global {
 export const DEV = {
   name: 'SkullMute',
   role: 'Solo maintainer',
-  blurb: 'Unemployed introvert Vietnamese dev. Grok is my non-judgmental coding buddy.',
+  blurb: 'Unemployed introvert Vietnamese dev. Two non-judgmental AI buddies do most of the heavy lifting — see below.',
   githubUrl: 'https://github.com/poli0981',
 } as const
+
+export interface AiTool {
+  name: string
+  vendor: string
+  model?: string
+  role: string
+  url: string
+}
+
+export const AI_TOOLS: AiTool[] = [
+  {
+    name: 'Grok',
+    vendor: 'xAI',
+    role: 'Original buddy. Late-night brainstorming, the Python pipeline rewrites, the v2.0.0 scraper refactor. Carried the early life of this repo.',
+    url: 'https://x.ai',
+  },
+  {
+    name: 'Claude Code',
+    vendor: 'Anthropic',
+    model: 'Claude Opus 4.7 (1M context)',
+    role: 'Newer recruit. Drove the v3.0.0 webapp + Tauri build and the v3.1.2 offline-link fix / About expansion / docs sweep. More cautious vibe — confirms before nuking anything.',
+    url: 'https://claude.com/claude-code',
+  },
+]
 
 export const ERROR_TEMPLATE_URL =
   'https://github.com/poli0981/free-games-itchio-list/issues/new?template=bug_report.yml'

--- a/webapp/src/lib/external-link.ts
+++ b/webapp/src/lib/external-link.ts
@@ -1,0 +1,10 @@
+import { isTauri } from './runtime'
+
+export async function openExternal(href: string): Promise<void> {
+  if (isTauri()) {
+    const { openUrl } = await import('@tauri-apps/plugin-opener')
+    await openUrl(href)
+    return
+  }
+  window.open(href, '_blank', 'noopener,noreferrer')
+}

--- a/webapp/src/routes/about.tsx
+++ b/webapp/src/routes/about.tsx
@@ -1,8 +1,34 @@
-import { ExternalLink } from 'lucide-react'
+import {
+  Bug,
+  Cloud,
+  Coffee,
+  ExternalLink as ExternalLinkIcon,
+  Gamepad2,
+  Library,
+  Globe,
+  Hash,
+  Heart,
+  MessagesSquare,
+  Video,
+  type LucideIcon,
+} from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-import { APP, THIRD_PARTY, UPSTREAM_DATA, type ThirdParty } from '@/lib/about'
+import { ExtLink } from '@/components/ext-link'
+import {
+  APP,
+  DEV,
+  ERROR_TEMPLATE_URL,
+  SOCIAL_GROUP_LABELS,
+  SOCIAL_LINKS,
+  THIRD_PARTY,
+  UPSTREAM_DATA,
+  type SocialGroup,
+  type SocialLink,
+  type ThirdParty,
+} from '@/lib/about'
 
 const CATEGORY_LABELS: Record<ThirdParty['category'], string> = {
   core: 'Core',
@@ -11,6 +37,20 @@ const CATEGORY_LABELS: Record<ThirdParty['category'], string> = {
   desktop: 'Desktop (Tauri)',
   dev: 'Dev tooling',
 }
+
+const SOCIAL_ICON: Record<string, LucideIcon> = {
+  x: Hash,
+  youtube: Video,
+  bluesky: Cloud,
+  mastodon: Hash,
+  'discord-repo': MessagesSquare,
+  'discord-game': MessagesSquare,
+  patreon: Heart,
+  kofi: Coffee,
+  steam: Gamepad2,
+}
+
+const SOCIAL_GROUP_ORDER: SocialGroup[] = ['social', 'community', 'support', 'gaming']
 
 function ThirdPartySection({ category }: { category: ThirdParty['category'] }) {
   const items = THIRD_PARTY.filter((t) => t.category === category)
@@ -24,16 +64,14 @@ function ThirdPartySection({ category }: { category: ThirdParty['category'] }) {
             key={t.name}
             className="flex items-center justify-between gap-2 rounded-md border p-2 text-sm"
           >
-            <a
+            <ExtLink
               href={t.url}
-              target="_blank"
-              rel="noreferrer"
               className="inline-flex items-center gap-1 truncate font-medium hover:underline"
               title={`${t.name} ${t.version}`}
             >
               {t.name}
-              <ExternalLink className="h-3 w-3 opacity-50" />
-            </a>
+              <ExternalLinkIcon className="h-3 w-3 opacity-50" />
+            </ExtLink>
             <div className="flex flex-shrink-0 items-center gap-2 text-xs">
               <span className="text-muted-foreground">{t.version}</span>
               <Badge variant="outline" className="font-mono text-xs">
@@ -44,6 +82,40 @@ function ThirdPartySection({ category }: { category: ThirdParty['category'] }) {
         ))}
       </ul>
     </div>
+  )
+}
+
+function SocialGroupSection({ group }: { group: SocialGroup }) {
+  const items = SOCIAL_LINKS.filter((s) => s.group === group)
+  if (items.length === 0) return null
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-muted-foreground">{SOCIAL_GROUP_LABELS[group]}</h3>
+      <ul className="grid grid-cols-1 gap-2 md:grid-cols-2">
+        {items.map((s) => (
+          <SocialItem key={s.platform} link={s} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function SocialItem({ link }: { link: SocialLink }) {
+  const Icon = SOCIAL_ICON[link.platform] ?? Globe
+  return (
+    <li className="rounded-md border">
+      <ExtLink
+        href={link.url}
+        className="flex items-center gap-3 p-2 text-sm hover:bg-accent hover:text-accent-foreground"
+      >
+        <Icon className="h-4 w-4 flex-shrink-0 opacity-70" />
+        <span className="min-w-0 flex-1 truncate">
+          <span className="font-medium">{link.label}</span>
+          <span className="ml-2 text-xs text-muted-foreground">{link.handle}</span>
+        </span>
+        <ExternalLinkIcon className="h-3 w-3 flex-shrink-0 opacity-50" />
+      </ExtLink>
+    </li>
   )
 }
 
@@ -62,9 +134,9 @@ export default function About() {
         <CardContent className="space-y-2 text-sm">
           <p>
             A read/write companion app for the{' '}
-            <a href={APP.repo} target="_blank" rel="noreferrer" className="font-medium hover:underline">
+            <ExtLink href={APP.repo} className="font-medium hover:underline">
               free-games-itchio-list
-            </a>{' '}
+            </ExtLink>{' '}
             catalog. Browse 500+ free games from itch.io, edit annotations, dispatch the scraper
             workflow with one click, and visualize the dataset.
           </p>
@@ -77,19 +149,73 @@ export default function About() {
 
       <Card className="mt-6">
         <CardHeader>
+          <CardTitle className="text-base">Developer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium">{DEV.name}</span>
+            <Badge variant="secondary" className="text-xs">
+              {DEV.role}
+            </Badge>
+          </div>
+          <p className="text-muted-foreground">{DEV.blurb}</p>
+          <ExtLink
+            href={DEV.githubUrl}
+            className="inline-flex items-center gap-1.5 text-sm font-medium hover:underline"
+          >
+            <Library className="h-4 w-4" />
+            {DEV.githubUrl.replace('https://', '')}
+            <ExternalLinkIcon className="h-3 w-3 opacity-50" />
+          </ExtLink>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Found a bug?</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground">
+            If something's broken — desktop or web — file it here so I see it. Grok will probably
+            patch it before I wake up :D
+          </p>
+          <Button asChild variant="default" size="sm">
+            <ExtLink href={ERROR_TEMPLATE_URL}>
+              <Bug className="h-4 w-4" />
+              Open bug report template
+              <ExternalLinkIcon className="h-3.5 w-3.5 opacity-80" />
+            </ExtLink>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Find me elsewhere</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            DMs open on most. Replies slow (introvert max level). Pick whichever channel fits.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {SOCIAL_GROUP_ORDER.map((group, i) => (
+            <div key={group} className="space-y-5">
+              {i > 0 && <Separator />}
+              <SocialGroupSection group={group} />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
           <CardTitle className="text-base">Upstream data attribution</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2 text-sm">
           <p>
             Source:{' '}
-            <a
-              href={UPSTREAM_DATA.url}
-              target="_blank"
-              rel="noreferrer"
-              className="font-medium hover:underline"
-            >
+            <ExtLink href={UPSTREAM_DATA.url} className="font-medium hover:underline">
               {UPSTREAM_DATA.source}
-            </a>
+            </ExtLink>
           </p>
           <p className="text-muted-foreground">{UPSTREAM_DATA.note}</p>
         </CardContent>

--- a/webapp/src/routes/about.tsx
+++ b/webapp/src/routes/about.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { ExtLink } from '@/components/ext-link'
 import {
+  AI_TOOLS,
   APP,
   DEV,
   ERROR_TEMPLATE_URL,
@@ -167,6 +168,32 @@ export default function About() {
             {DEV.githubUrl.replace('https://', '')}
             <ExternalLinkIcon className="h-3 w-3 opacity-50" />
           </ExtLink>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">AI co-authors</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            No real co-maintainers (introvert max level). These two LLMs are the closest thing.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {AI_TOOLS.map((tool) => (
+            <div key={tool.name} className="space-y-1.5 rounded-md border p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <ExtLink href={tool.url} className="inline-flex items-center gap-1 font-medium hover:underline">
+                  {tool.name}
+                  <ExternalLinkIcon className="h-3 w-3 opacity-50" />
+                </ExtLink>
+                <Badge variant="outline" className="text-xs">{tool.vendor}</Badge>
+                {tool.model && (
+                  <Badge variant="secondary" className="font-mono text-xs">{tool.model}</Badge>
+                )}
+              </div>
+              <p className="text-muted-foreground">{tool.role}</p>
+            </div>
+          ))}
         </CardContent>
       </Card>
 

--- a/webapp/src/routes/game-detail.tsx
+++ b/webapp/src/routes/game-detail.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
+import { ExtLink } from '@/components/ext-link'
 import { EditGameForm } from '@/components/edit-game-form'
 import { useGameBySlug } from '@/hooks/useGameBySlug'
 import { useAuth } from '@/stores/auth'
@@ -92,10 +93,10 @@ function GameDetailView({ game }: { game: Game }) {
             <p className="mt-3 text-sm">{game.description}</p>
             <div className="mt-auto pt-4">
               <Button variant="outline" size="sm" asChild>
-                <a href={game.url} target="_blank" rel="noreferrer">
+                <ExtLink href={game.url}>
                   Open on itch.io
                   <ExternalLink className="h-4 w-4" />
-                </a>
+                </ExtLink>
               </Button>
             </div>
           </div>
@@ -185,7 +186,7 @@ function GameDetailView({ game }: { game: Game }) {
 
       <Separator className="my-6" />
       <p className="text-xs text-muted-foreground">
-        URL: <a href={game.url} target="_blank" rel="noreferrer" className="hover:underline">{game.url}</a>
+        URL: <ExtLink href={game.url} className="hover:underline">{game.url}</ExtLink>
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary

Doc-only-ish patch that surfaces **Claude Code (Anthropic — Claude Opus 4.7, 1M context)** alongside the existing Grok credit, since Claude Code drove the v3.0.0 webapp/Tauri scaffold and the v3.1.2 fixes. Grok stays — both buddies share the workload now.

## Changes

- **About page** — new **"AI co-authors"** Card (between Developer and Found-a-bug). Each tool shows: linked name, vendor badge, model badge (Grok has no model field, Claude shows `Claude Opus 4.7 (1M context)`), and a one-line role describing what it shipped in this repo.
- **`webapp/src/lib/about.ts`** — new `AiTool` interface + `AI_TOOLS` const so the AI credit data follows the same structured pattern as `THIRD_PARTY` and `SOCIAL_LINKS`.
- **`docs/ACKNOWLEDGEMENTS.md`** — Claude Code added under "Special Thanks" alongside Grok.
- **`docs/My_Stuff.md`** — "The Real MVP" → "The Real MVPs" (plural) with both buddies.
- **`CONTRIBUTING.md`** — opening line updated to mention both AI buddies.
- **`README.md`** — version badge → 3.1.3.
- **`CHANGELOG.md`** — v3.1.3 entry.

## Not touched (intentional)

- Issue / PR templates — the "Grok fixes most" jokes are part of the template UX persona; loading them with Claude mentions would dilute the voice.
- Tauri version (`webapp/src-tauri/{Cargo.toml,tauri.conf.json}`) and `webapp/package.json` — no desktop binary changes since v3.1.2; consistent with how v3.1.2 was tagged.

## Test plan

- [x] `npm run build` — TS clean, About chunk 10.57 kB → 11.99 kB (gzip 3.25 → 3.63 kB).
- [x] `npm run lint` — only pre-existing issues in shadcn primitives + `routes/games.tsx`; no new issues from changed files.
- [x] User confirmed test okay before tagging.
- [ ] Post-merge: `deploy_webapp.yml` rebuilds GitHub Pages.
- [ ] Post-merge: `release_desktop.yml` triggers on `v3.1.3` tag → multi-platform Tauri installers (no native binary changes; same opener-fix runtime as v3.1.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)