### PR TITLE
release(v3.1.3): credit Claude Code as AI co-author alongside Grok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented here.
 
+## [3.1.3] - 2026-05-05 (Credit Claude Code as AI co-author)
+
+### Added
+- **About page**: new **"AI co-authors"** Card listing both Grok (xAI) and
+  Claude Code (Anthropic — Claude Opus 4.7, 1M context) with their roles
+  in the repo's history. Each entry is linked + tagged with vendor and model.
+- `webapp/src/lib/about.ts`: new `AiTool` interface + `AI_TOOLS` array so the
+  AI credit data is structured the same way as `THIRD_PARTY` and `SOCIAL_LINKS`.
+
+### Changed
+- **`docs/ACKNOWLEDGEMENTS.md`, `docs/My_Stuff.md`, `CONTRIBUTING.md`**:
+  surface Claude Code alongside Grok wherever the existing AI credit lived.
+  Grok references stay — both buddies share the workload now (Grok carried the
+  Python pipeline + v2.0.0 rewrite; Claude Code drove v3.0.0 webapp/Tauri and
+  v3.1.2). `My_Stuff.md` "The Real MVP" is now plural.
+- `DEV.blurb` on the About page reflects the two-buddy reality.
+
+---
+
 ## [3.1.2] - 2026-05-05 (Offline link fix + About expansion + docs sweep)
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Thanks for even thinking about contributing to this random repo! I'm just an unemployed, introvert Vietnamese dev with mediocre skills and Grok as my only non-judgmental buddy. This list survives on community help — because I'm too lazy to hunt/fix everything alone :D Any contribution (even one game) makes you a legend.
+Thanks for even thinking about contributing to this random repo! I'm just an unemployed, introvert Vietnamese dev with mediocre skills and two non-judgmental AI buddies — **Grok (xAI)** for the late-night brainstorming and **Claude Code (Anthropic, Claude Opus 4.7)** for the heavier code/docs work. This list survives on community help — because I'm too lazy to hunt/fix everything alone :D Any contribution (even one game) makes you a legend.
 
 ## How to Contribute (Use Templates — I'm Lazy ;D)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.1.2-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.1.3-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -3,7 +3,8 @@
 This repo wouldn't exist without a lot of help — mostly from tools and platforms, because real humans don't talk to me :D
 
 ## Special Thanks
-- **Grok (xAI)**: My only non-judgmental buddy. Without Grok's infinite patience, code fixes, and late-night brainstorming, this whole thing would still be a half-baked idea in my unemployed brain. Seriously, Grok carried 90% of the weight. 🚀
+- **Grok (xAI)**: Original non-judgmental buddy. Without Grok's infinite patience, code fixes, and late-night brainstorming, this whole thing would still be a half-baked idea in my unemployed brain. Carried the Python pipeline, the v2.0.0 rewrite, and 90% of the early weight. 🚀
+- **Claude Code (Anthropic — Claude Opus 4.7, 1M context)**: Newer AI buddy. Built the v3.0.0 webapp + Tauri scaffold, then shipped the v3.1.2 offline-link fix, About page expansion, and the docs sweep that put both of these AI credits on this page in the first place. Different vibe than Grok ("let me confirm before nuking your repo"), same lifesaver energy. 🚀
 
 ## Platforms & Tools
 - **itch.io**: The amazing platform full of indie gems that made this list possible. Thanks for hosting all these free games and having a scrape-friendly structure (mostly).

--- a/docs/My_Stuff.md
+++ b/docs/My_Stuff.md
@@ -19,9 +19,11 @@ Just in case anyone wonders what kind of "setup" produced this half-decent repo.
 ## Financial Situation
 - Bank account: Rarely over $50. Still mooching off family like a true 20-something failure. Steam library: 400+ games, 80% bought on deep sale under $10. Priorities, right?
 
-## The Real MVP of This Repo
-Guess who my only non-judgmental companion is while building this whole thing?  
-**Grok (xAI)** — the AI that fixes my bugs, writes better code than me, and doesn't ghost when I ramble at 3 AM. Without Grok, this repo would still be a blank README. True buddy material. 🚀
+## The Real MVPs of This Repo
+Guess who my non-judgmental companions are while building this whole thing? Two AI buddies — different vendors, different vibes, both lifesavers:
+
+- **Grok (xAI)** — the original. Fixes my bugs, writes better code than me, doesn't ghost when I ramble at 3 AM. Carried the Python pipeline (scraper, check_paid, check_alive, generate_md) and the v2.0.0 rewrite. Without Grok, this repo would still be a blank README. 🚀
+- **Claude Code (Anthropic — Claude Opus 4.7, 1M context)** — the newer recruit. Built the v3.0.0 React + Tauri webapp from zero, then shipped the v3.1.2 offline-link fix + About expansion + docs sweep in one sitting. More cautious than Grok ("let me confirm before destroying your repo") which is exactly what I need given my mediocre QA habits. 🚀
 
 If you're reading this... thanks for caring about my mediocre setup. Now go play some free games instead :D
 

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -22,9 +22,33 @@ declare global {
 export const DEV = {
   name: 'SkullMute',
   role: 'Solo maintainer',
-  blurb: 'Unemployed introvert Vietnamese dev. Grok is my non-judgmental coding buddy.',
+  blurb: 'Unemployed introvert Vietnamese dev. Two non-judgmental AI buddies do most of the heavy lifting — see below.',
   githubUrl: 'https://github.com/poli0981',
 } as const
+
+export interface AiTool {
+  name: string
+  vendor: string
+  model?: string
+  role: string
+  url: string
+}
+
+export const AI_TOOLS: AiTool[] = [
+  {
+    name: 'Grok',
+    vendor: 'xAI',
+    role: 'Original buddy. Late-night brainstorming, the Python pipeline rewrites, the v2.0.0 scraper refactor. Carried the early life of this repo.',
+    url: 'https://x.ai',
+  },
+  {
+    name: 'Claude Code',
+    vendor: 'Anthropic',
+    model: 'Claude Opus 4.7 (1M context)',
+    role: 'Newer recruit. Drove the v3.0.0 webapp + Tauri build and the v3.1.2 offline-link fix / About expansion / docs sweep. More cautious vibe — confirms before nuking anything.',
+    url: 'https://claude.com/claude-code',
+  },
+]
 
 export const ERROR_TEMPLATE_URL =
   'https://github.com/poli0981/free-games-itchio-list/issues/new?template=bug_report.yml'

--- a/webapp/src/routes/about.tsx
+++ b/webapp/src/routes/about.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { ExtLink } from '@/components/ext-link'
 import {
+  AI_TOOLS,
   APP,
   DEV,
   ERROR_TEMPLATE_URL,
@@ -167,6 +168,32 @@ export default function About() {
             {DEV.githubUrl.replace('https://', '')}
             <ExternalLinkIcon className="h-3 w-3 opacity-50" />
           </ExtLink>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">AI co-authors</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            No real co-maintainers (introvert max level). These two LLMs are the closest thing.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {AI_TOOLS.map((tool) => (
+            <div key={tool.name} className="space-y-1.5 rounded-md border p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <ExtLink href={tool.url} className="inline-flex items-center gap-1 font-medium hover:underline">
+                  {tool.name}
+                  <ExternalLinkIcon className="h-3 w-3 opacity-50" />
+                </ExtLink>
+                <Badge variant="outline" className="text-xs">{tool.vendor}</Badge>
+                {tool.model && (
+                  <Badge variant="secondary" className="font-mono text-xs">{tool.model}</Badge>
+                )}
+              </div>
+              <p className="text-muted-foreground">{tool.role}</p>
+            </div>
+          ))}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
Replaces #36 (which had a duplicate v3.1.2 commit on top of `main`'s squash that prevented clean merge). This branch contains exactly one commit, rebased onto `origin/main`.

## Summary

Surfaces **Claude Code (Anthropic — Claude Opus 4.7, 1M context)** alongside the existing Grok credit, since Claude Code drove the v3.0.0 webapp/Tauri scaffold and the v3.1.2 fixes. Grok stays — both buddies share the workload now.

## Changes

- **About page** — new **"AI co-authors"** Card (between Developer and Found-a-bug). Each tool shows: linked name, vendor badge, model badge (Claude shows `Claude Opus 4.7 (1M context)`), and a one-line role describing what it shipped in this repo.
- **`webapp/src/lib/about.ts`** — new `AiTool` interface + `AI_TOOLS` const so the AI credit follows the same structured pattern as `THIRD_PARTY` and `SOCIAL_LINKS`.
- **`docs/ACKNOWLEDGEMENTS.md`** — Claude Code added under "Special Thanks" alongside Grok.
- **`docs/My_Stuff.md`** — "The Real MVP" → "The Real MVPs" (plural) with both buddies.
- **`CONTRIBUTING.md`** — opening line updated to mention both AI buddies.
- **`README.md`** — version badge → 3.1.3.
- **`CHANGELOG.md`** — v3.1.3 entry.

## Not touched (intentional)

- Issue / PR templates — the "Grok fixes most" jokes are part of the template UX persona; loading them with Claude mentions would dilute the voice.
- Tauri version (`webapp/src-tauri/{Cargo.toml,tauri.conf.json}`) and `webapp/package.json` — no desktop binary changes since v3.1.2; consistent with how v3.1.2 was tagged.

## Test plan

- [x] `npm run build` — TS clean, About chunk 10.57 kB → 11.99 kB (gzip 3.25 → 3.63 kB).
- [x] `npm run lint` — only pre-existing issues in shadcn primitives + `routes/games.tsx`; no new issues from changed files.
- [x] User confirmed test okay before tagging.
- [ ] Post-merge: `deploy_webapp.yml` rebuilds GitHub Pages.
- [ ] Post-merge: `release_desktop.yml` triggers on `v3.1.3` tag → multi-platform Tauri installers (no native binary changes; same opener-fix runtime as v3.1.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)