### PR TITLE
release(v3.1.4): legal docs rewrite, Vietnamese i18n, Legal Card, UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented here.
 
+## [3.1.4] - 2026-05-05 (Legal docs rewrite + Vietnamese i18n + Legal Card + UI polish)
+
+### Added
+- **Vietnamese translations** under [`docs/i18n/vi/`](docs/i18n/vi/) — full
+  translations of the four legal docs (DISCLAIMER, EULA, ToS, PrivacyPolicy)
+  plus CONTRIBUTING, CODE_OF_CONDUCT, and SECURITY. Each file notes that the
+  English version is the controlling text for legal interpretation.
+- **`README.vi.md`** at repo root — Vietnamese mirror of the main README, with a
+  language badge and a link back to the English version.
+- **About page → "Legal & policies" Card** — single place to access all policy
+  files (Disclaimer, EULA, ToS, Privacy, Code of Conduct, Security, License,
+  Changelog) plus a pointer to the Vietnamese translations.
+- **`webapp/src/lib/about.ts`**: `LegalLink` interface + `LEGAL_LINKS` array +
+  `LEGAL_VI_INDEX_URL`. Same structured pattern as `THIRD_PARTY` and
+  `SOCIAL_LINKS`.
+
+### Changed
+- **`docs/DISCLAIMER.md`, `docs/EULA.md`, `docs/ToS.md`, `docs/PrivacyPolicy.md`**:
+  rewritten to be tighter and more enforceable while keeping the project's voice.
+  Each doc now has a TL;DR, numbered sections, definitions, severability,
+  governing law (Socialist Republic of Vietnam), explicit "not legal advice"
+  notice, and a removal-request path. Privacy Policy adds a per-storage table
+  for what the webapp persists locally and a step-by-step PAT lifecycle.
+- **`README.md`** version badge → 3.1.4 plus a Vietnamese language badge and a
+  short pointer to `README.vi.md` and `docs/i18n/vi/`.
+
+### Optional UI
+- **Tauri desktop**: maximize button is now disabled (`maximizable: false` in
+  `webapp/src-tauri/tauri.conf.json`). Window is still resizable; only the
+  full-window-maximize action is locked.
+- **DataTable**: scrollbar hidden via a new `.scrollbar-hide` Tailwind utility
+  added to `webapp/src/index.css`. Scrolling still works; the chrome is gone.
+
+---
+
 ## [3.1.3] - 2026-05-05 (Credit Claude Code as AI co-author)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.1.3-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.1.4-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Tiếng Việt](https://img.shields.io/badge/lang-Tiếng%20Việt-red.svg)](README.vi.md)
+
+> 🇻🇳 Tiếng Việt: see [`README.vi.md`](README.vi.md). Vietnamese translations of the policy docs live in [`docs/i18n/vi/`](docs/i18n/vi/). The English versions in this repo remain controlling for legal interpretation.
 
 A curated, auto-updating catalog of free games on [itch.io](https://itch.io). Games are scraped, validated, and
 organized into browsable markdown tables — updated daily via GitHub Actions.

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,124 @@
+# Danh sách Game Itch.io Miễn Phí
+
+[![Version](https://img.shields.io/badge/version-3.1.4-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md)
+
+> Đây là bản dịch tiếng Việt mang tính tham khảo cho cộng đồng. Bản tiếng Anh tại [`README.md`](README.md) là bản chính thức cho mọi điều khoản pháp lý / kỹ thuật.
+
+Một danh mục được duy trì tự động của các game miễn phí trên [itch.io](https://itch.io). Game được cào (scrape), xác thực và tổ chức thành các bảng markdown có thể duyệt — cập nhật hàng ngày qua GitHub Actions.
+
+## Mục lục
+
+- [Duyệt theo thể loại](#duyệt-theo-thể-loại)
+- [Webapp (duyệt + sửa + analytics)](#webapp-duyệt--sửa--analytics)
+- [Cách hoạt động](#cách-hoạt-động)
+- [Cấu trúc dự án](#cấu-trúc-dự-án)
+- [Tự động hóa (GitHub Actions)](#tự-động-hóa-github-actions)
+- [Đóng góp](#đóng-góp)
+- [Kết nối / hỗ trợ](#kết-nối--hỗ-trợ)
+- [Pháp lý](#pháp-lý)
+
+## Duyệt theo thể loại
+
+Các bảng được tự tạo và chia theo thể loại chính (tối đa 300 game / file). Thể loại mới sẽ tự xuất hiện khi có game được thêm vào.
+
+- [Action](lists/action.md)
+- [Adventure](lists/adventure.md)
+- [Puzzle](lists/puzzle.md)
+- [Horror](lists/horror.md)
+- [Visual Novel](lists/visual_novel.md)
+- [Simulation](lists/simulation.md)
+- [Platformer](lists/platformer.md)
+- [Other](lists/other.md)
+- *(các thể loại khác sẽ tự tạo khi cần)*
+
+## Webapp (duyệt + sửa + analytics)
+
+Một SPA React + TypeScript trong [`webapp/`](webapp/) cung cấp giao diện duyệt trên cùng catalog JSON: DataTable virtualized cho 500+ game, faceted filter (thể loại / trạng thái / nền tảng / NSFW), 9 chart (Recharts), bulk edit/delete qua GitHub Git Data API, và một flow "add" một-click dispatch workflow scraper với input URL.
+
+- **Bản web**: deploy lên GitHub Pages bởi [`.github/workflows/deploy_webapp.yml`](.github/workflows/deploy_webapp.yml) — push vào `main` chạm `webapp/` sẽ tự ship. (Setup một lần: repo Settings → Pages → Source = "GitHub Actions".)
+- **Bản desktop (tùy chọn)**: cùng code React đóng gói thành app native Tauri 2 cho Windows / macOS / Linux. Xem [`webapp/TAURI.md`](webapp/TAURI.md) để biết yêu cầu và `npm run tauri:dev`.
+- **Auth**: PAT fine-grained với `contents:write` + `actions:write` được mã hóa AES-GCM trong localStorage (PBKDF2-SHA256). Token đã giải mã chỉ tồn tại trong bộ nhớ.
+- **Edit commit dạng `chore(webapp): …`** để dễ lọc khỏi commit của scraper hàng ngày.
+
+Dev cục bộ:
+
+```sh
+cd webapp
+npm install
+npm run dev          # http://localhost:5173
+npm run build        # ghi vào docs/app/
+npm run tauri:dev    # native desktop (cần Rust)
+```
+
+## Cách hoạt động
+
+```
+temp_link.json          →   update_info.py        →   data_game/
+(URL mới thêm vào đây)      (scrape + check free)     game_info_001.json
+                                                      game_info_002.json ...
+                                                          │
+                ┌─────────────────────────────────────────┘
+                ▼                                        ▼
+        generate_md.py                           check_paid.py
+        (bảng MD)                                check_alive.py
+                                                 (cleanup)
+```
+
+1. **Thêm link** — dán URL itch.io vào `scripts/temp_link.json` (thủ công, qua PR, hoặc qua extension trình duyệt đi kèm).
+2. **Scrape hàng ngày** — GitHub Actions chạy `update_info.py` lúc 03:00 UTC. Mỗi link được fetch, kiểm tra trạng thái free và cào metadata. Game trả phí tự bị bỏ qua.
+3. **Tạo bảng** — `generate_md.py` nhóm game theo thể loại chính và xuất các bảng markdown vào `/lists/`.
+4. **Cleanup định kỳ** — mỗi 2 ngày, `check_paid.py` kiểm tra lại game nào đã chuyển sang trả phí, và `check_alive.py` xác minh các trang game còn tồn tại. Game bị gỡ được log kèm lý do.
+
+## Cấu trúc dự án
+
+Xem [`README.md`](README.md#project-structure) phiên bản tiếng Anh để có sơ đồ thư mục đầy đủ và mới nhất.
+
+## Tự động hóa (GitHub Actions)
+
+| Workflow | Lịch | Mục đích |
+|---|---|---|
+| Update game info | Hàng ngày 03:00 UTC | Scrape link mới từ `temp_link.json` (+ input `url` tùy chọn từ webapp), bỏ qua game trả phí |
+| Generate tables | Sau update/checks | Build lại các bảng markdown trong `/lists/` |
+| Check paid games | Mỗi 2 ngày 04:00 UTC | Gỡ game đã chuyển sang trả phí |
+| Check dead links | Mỗi 2 ngày 07:00 UTC | Gỡ trang game 404/410 |
+| Log deleted games | Sau check workflows | Xuất log gỡ ra `deleted_games.txt` |
+| Deploy webapp | Khi push vào main | Build `webapp/` → GitHub Pages (`docs/app/`) |
+| Release desktop | Khi push tag `v*` | Build installer Tauri (Win/macOS/Linux) → draft Release |
+
+Tất cả workflow có rate-limit (delay ngẫu nhiên, batch pause) để tránh bị itch.io block. Lỗi mạng được coi là tạm thời — game chỉ bị gỡ khi xác nhận 404/410 hoặc xác nhận trả phí.
+
+## Đóng góp
+
+Xem [CONTRIBUTING.vi](docs/i18n/vi/CONTRIBUTING.md) (hoặc [bản tiếng Anh CONTRIBUTING.md](CONTRIBUTING.md) cho bản chính thức).
+
+- **Thêm game** — dùng issue template "Add New Games" (tối đa 50 link / issue).
+- **Báo bug** — dùng template "Bug Report".
+- **Đề xuất tính năng** — mở issue hoặc gửi PR.
+
+Người đóng góp được ghi nhận trong [ACKNOWLEDGEMENTS.md](docs/ACKNOWLEDGEMENTS.md).
+
+## Kết nối / hỗ trợ
+
+Hai server Discord giờ đã tồn tại (câu "if I ever make one" chính thức lỗi thời):
+
+- **Chat**: Discord — [Repo discussion](https://discord.gg/2aNR3aVt) · [Game chat](https://discord.gg/kDM9GMu5vm)
+- **Mạng xã hội**: [X/@SkullMute0011](https://x.com/SkullMute0011) · [YouTube/@SkullMute](https://youtube.com/@SkullMute) · [Bluesky](https://bsky.app/profile/skullmute0011.bsky.social) · [Mastodon](https://mastodon.social/@skullmute1122)
+- **Hỗ trợ** (hoàn toàn tùy chọn): [Patreon](https://patreon.com/skullmute) · [Ko-fi](https://ko-fi.com/skullmute) · [Buy Me a Coffee](https://buymeacoffee.com/skullmute)
+- **Gaming**: [Steam profile](https://steamcommunity.com/profiles/76561199544666292/)
+
+DM mở khắp nơi — trả lời chậm, introvert max level. Trang About trong [webapp](https://poli0981.github.io/free-games-itchio-list/app/#/about) có cùng danh sách dạng nút bấm.
+
+## Pháp lý
+
+Bản tiếng Việt nằm trong [`docs/i18n/vi/`](docs/i18n/vi/) — bản tiếng Anh là bản chính thức cho mọi giải thích pháp lý.
+
+- [Disclaimer](docs/i18n/vi/DISCLAIMER.md) ([EN](docs/DISCLAIMER.md))
+- [Privacy Policy](docs/i18n/vi/PrivacyPolicy.md) ([EN](docs/PrivacyPolicy.md))
+- [Terms of Use](docs/i18n/vi/ToS.md) ([EN](docs/ToS.md))
+- [EULA](docs/i18n/vi/EULA.md) ([EN](docs/EULA.md))
+- [Code of Conduct](docs/i18n/vi/CODE_OF_CONDUCT.md) ([EN](CODE_OF_CONDUCT.md))
+- [Security](docs/i18n/vi/SECURITY.md) ([EN](SECURITY.md))
+
+Cấp phép theo [MIT](LICENSE).

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -1,21 +1,61 @@
 # Disclaimer
 
-This repository is just a fun side project — a curated list of free-to-play games on itch.io, scraped and maintained by an unemployed Vietnamese dev with too much free time and his AI buddy Grok. It's built purely for vibes, boredom relief, and sharing indie gems. No grand promises here.
+Last updated: 2026-05-05
 
-## No Warranties Whatsoever
-The content in this repository (game links, descriptions, tables, etc.) is provided **"AS IS"** without any warranties of any kind, express or implied. This includes, but is not limited to:
+This repository — `free-games-itchio-list` — is a hobby project: a curated index of free-to-play games hosted on [itch.io](https://itch.io), maintained by an unemployed Vietnamese dev with two AI buddies (Grok and Claude Code). Built for vibes, indie discovery, and boredom relief. No grand promises — but the legal-shaped wording below is real.
 
-- **Quality & Enjoyment**: Some games might be absolute bangers. Others might be boring, broken, or straight-up frustrating. I make no guarantees you'll have fun. Your mileage may vary — dramatically.
-- **Safety & Viruses**: All games are linked directly from itch.io (a reputable platform), and the "Safe?" column defaults to "?" because I don't scan every download. Download and play at your own risk. Good luck out there.
-- **NSFW Content**: The "NSFW" flag is auto-detected from tags/warnings, but it might miss stuff or false-positive. If you're not into adult content, double-check the game page yourself.
-- **Accuracy & Completeness**: This list is far from perfect. Games might change, get removed, or I might miss amazing ones. It's not 100% accurate or comprehensive — kinda like my life :D
+> **TL;DR**: Use the catalog, the webapp, and the desktop app at your own risk. The maintainer makes no warranties, accepts no liability, and is not responsible for the games linked here.
 
-## Liability? Nope
-In no event shall the author (that's me, the unemployed dev) or contributors be liable for any issues arising from using this repository, including but not limited to: game crashes, lost progress, wasted time, existential dread from bad gameplay, or any damages whatsoever.
+## 1. "AS IS" basis
 
-If you encounter problems with a game (crashes, bugs, it's boring, etc.), please contact the game developer directly or report it on itch.io. I'm just the guy aggregating links — I don't make or support the games.
+The contents of this repository — including but not limited to the JSON catalog (`data_game/`), generated tables (`lists/`), Python pipeline (`scripts/`), webapp (`webapp/`), Tauri desktop wrapper (`webapp/src-tauri/`), and documentation — are provided **"AS IS"** and **"AS AVAILABLE"**, without warranty of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, accuracy, completeness, non-infringement, or uninterrupted operation.
 
-## Final Vibes
-This is just a list. Nothing more. Have fun hunting free games, stay safe, and remember: life's too short to take random GitHub repos seriously.
+## 2. No warranty as to the games
 
-Built with boredom and Grok's help. 🚀
+This repository is a directory of links and metadata. **It does not host, develop, distribute, or endorse the games it indexes.** All games are linked directly to itch.io and remain the property of their respective developers and publishers.
+
+The maintainer makes no warranty regarding any game's:
+
+- **Quality, enjoyment, or playability** — some titles are gems, others are jank, plenty are between. Your taste, your call.
+- **Safety, integrity, or freedom from malware** — the `safe_virus` field defaults to `?` because individual downloads are not scanned. Treat every download as untrusted until you verify it yourself with reputable anti-malware tools.
+- **NSFW classification** — the `nsfw` flag is auto-detected from itch.io tags / warnings / description text and is best-effort. Confirm the game page yourself before downloading if NSFW content matters to you (in either direction).
+- **Accuracy of metadata** — names, descriptions, genres, ratings, platforms, and other fields are scraped from itch.io and reflect the page state at the time of the last scrape. itch.io page changes (renames, removals, paywall additions) propagate on the next scheduled cleanup but may lag.
+- **Free-to-play status** — verified at scrape time; a game can become paid afterwards. The `check_paid.py` job re-verifies every two days and removes confirmed paid games, but a brief window of staleness is possible.
+
+## 3. No liability
+
+To the maximum extent permitted by applicable law, the maintainer and any contributors shall not be liable for any direct, indirect, incidental, consequential, special, exemplary, or punitive damages arising out of or in connection with:
+
+- Use of this repository, the webapp, the desktop app, or any code or data herein.
+- Inability to use any of the above (e.g. site downtime, deploy failure, broken installer).
+- Any game accessed via links in the catalog (crashes, lost saves, data loss, hardware damage, malware, account compromise on third-party platforms, regret).
+- Errors, omissions, or inaccuracies in the catalog data.
+
+This applies even if the maintainer has been advised of the possibility of such damages.
+
+## 4. Third-party content
+
+Game pages, screenshots, descriptions, tags, ratings, and thumbnails are the property of their respective developers/publishers and itch.io. They appear here under fair-use principles for the purposes of indexing and discovery. If you are a developer and want your game removed, see **Removal requests** below.
+
+## 5. Removal requests
+
+If you are a game developer and want your title removed from the index:
+
+- File a **[Remove Games]** issue (`.github/ISSUE_TEMPLATE/remove_game.yml`) with the box "I'm the dev and don't want it listed" checked.
+- Or DM via any channel listed on the [About page](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+
+Removals are processed manually. Expect a few days (unemployed schedule, but not weeks).
+
+## 6. No legal advice
+
+Nothing in this document is legal advice. It is a hobby-project disclaimer drafted by a non-lawyer with AI assistance, and its enforceability depends on your jurisdiction. If you actually need legal certainty for something, hire a real lawyer.
+
+## 7. Governing law and severability
+
+This Disclaimer is governed by the laws of the **Socialist Republic of Vietnam**, without regard to conflict-of-law principles. If any provision is held unenforceable in a particular jurisdiction, the remaining provisions remain in effect.
+
+## 8. Final vibes
+
+It's still just a list of free games made by a tired dev and two LLMs. Have fun, stay safe, scan your downloads, and remember: life's too short to take random GitHub repos to court.
+
+Built with boredom, two AI buddies, and a deep wish to never see a real lawsuit. 🚀

--- a/docs/EULA.md
+++ b/docs/EULA.md
@@ -1,36 +1,81 @@
-﻿# End-User License Agreement (EULA)
+# End-User License Agreement (EULA)
 
-Last updated: December 28, 2025
+Last updated: 2026-05-05
 
-Yo, welcome to this super low-effort GitHub repo — a curated list of free itch.io games, scraped and sorta-maintained by an unemployed Vietnamese dev who's got nothing better to do, with heavy assistance from his AI buddy Grok. This isn't real software you "install" — it's just code, markdown, and links. But since everyone loves an EULA, here you go.
+This EULA applies to the **code and content of `free-games-itchio-list`** — the JSON catalog, the Python pipeline, the React webapp, the Tauri desktop app, the markdown tables, and the documentation. It does **not** cover the games themselves, which are licensed separately by their developers via itch.io.
 
-## 1. Grant of License
-Under the MIT License (see [LICENSE](LICENSE) for the real deal), you're free to:
-- Use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the stuff in this repo.
-- Do whatever, as long as you keep the copyright notice and disclaimer.
+> **TL;DR**: This repo is MIT-licensed. Fork, modify, redistribute — keep the copyright notice, don't blame the maintainer if it breaks. The games are not yours just because they're listed here.
 
-Basically: go wild. Fork it, improve it, laugh at my mediocre code. Just don't blame me if it breaks.
+## 1. Definitions
 
-## 2. No Warranties
-This repo and everything in it is provided **"AS IS"** with **ZERO** warranties. No promises it works, is safe, is fun, or won't waste your time. Scripts might break, links might die, games might suck. Your problem, not mine.
+- **"The Repository"** — `free-games-itchio-list` on GitHub at <https://github.com/poli0981/free-games-itchio-list>, including all source code, data files, markdown tables, and documentation.
+- **"The Webapp"** — the React + TypeScript application in `webapp/`, deployed at <https://poli0981.github.io/free-games-itchio-list/app/>.
+- **"The Desktop App"** — the Tauri 2 native build of the Webapp, distributed as installers via GitHub Releases.
+- **"The Catalog"** — the structured game metadata in `data_game/` and the rendered markdown tables in `lists/`.
+- **"The Maintainer"** — the GitHub user `poli0981` (a.k.a. SkullMute), the author of this Repository.
+- **"You"** — any natural person, organization, or automated agent that accesses, downloads, clones, forks, runs, modifies, or otherwise uses the Repository or any part thereof.
 
-Full details in [DISCLAIMER](docs/DISCLAIMER.md) — because duplication is fun.
+## 2. Grant of license
 
-## 3. Limitation of Liability
-I'm not liable for anything. Ever. No damages, no lost time, no existential crisis from bad games. If something goes wrong (virus? crash? boredom?), tough luck. Download/play at your own risk.
+The Repository is licensed under the **MIT License** (see [`LICENSE`](../LICENSE) for the canonical text). Subject to that license, You are granted a worldwide, royalty-free, non-exclusive, perpetual right to:
+
+- Use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the code, data, and documentation in the Repository.
+- Run the Webapp and the Desktop App for any purpose, personal or commercial.
+- Build derivative works (forks, patches, ports, repackages).
+
+The MIT license terms apply in full. Two practical reminders:
+
+- **Keep the copyright and license notice** when you redistribute substantial portions.
+- **No warranty.** See [DISCLAIMER](DISCLAIMER.md).
+
+## 3. Scope — what this license does NOT cover
+
+This EULA does not grant any rights to:
+
+- **The games indexed by the Catalog.** Each game is the intellectual property of its respective developer and is licensed by them via itch.io. The Catalog provides a link and metadata only; downloading, playing, modifying, or redistributing a game is governed by the developer's own terms and itch.io's terms.
+- **Third-party libraries.** The Webapp depends on numerous open-source packages (React, Tauri, shadcn/ui, etc.), each under its own license — see the **Third-party software** section of the [About page](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+- **itch.io trademarks, logos, or service marks.** These belong to itch corp and are referenced for identification only.
+- **Thumbnails, screenshots, descriptions, or trailers** of indexed games. These are reproduced under fair-use principles for indexing/discovery and remain the property of their owners.
 
 ## 4. Acceptance
-By cloning, forking, viewing, or even thinking about this repo, you accept this EULA. Don't like it? Delete your clone and play something on easy mode (like me).
 
-## 5. Termination
-I can change or nuke this repo anytime. No notice. It's GitHub — backup if you care.
+You accept this EULA by performing any of: cloning, forking, downloading, installing, running, modifying, or otherwise using the Repository, the Webapp, or the Desktop App. If You do not agree, do not use them and delete any local copies.
 
-## 6. Governing Law
-Governed by the laws of... my couch in Vietnam. Disputes settled by whoever wins a noob-friendly game.
+## 5. Restrictions
 
-## Final Vibes
-This is just a hobby project born from unemployment and boredom. Use it, abuse it, ignore it. Have fun hunting free games — or don't. Nobody's judging (except maybe me, at myself).
+While the MIT license is permissive, You agree not to:
 
-Built with zero budget, too much free time, and Grok's infinite patience. 🚀
+- Use the Repository or its components to host, distribute, or facilitate the distribution of malware, phishing pages, or content that violates applicable law.
+- Misrepresent the origin of the Repository (e.g. claim authorship of unmodified copies).
+- Use the Maintainer's name, the GitHub handle `poli0981`, or the alias "SkullMute" to endorse or promote derivative works without prior written permission.
+- Use the Webapp's GitHub PAT-handling features to access GitHub repositories or APIs without proper authorization from those resources' owners.
 
-**P/S:** Nobody reads EULAs anyway. You're probably the first :D
+These restrictions are in addition to, not in replacement of, the MIT License terms.
+
+## 6. Updates and termination
+
+The Maintainer may update, modify, archive, or delete the Repository at any time without notice. Tagged releases (`vX.Y.Z`) are immutable on GitHub Releases unless explicitly retracted; the `main` branch is not.
+
+Your rights under this EULA terminate automatically if You materially breach it. The MIT License grant survives termination of this EULA to the extent the MIT terms permit.
+
+## 7. Governing law
+
+This EULA is governed by the laws of the **Socialist Republic of Vietnam**, without regard to conflict-of-law principles. Any dispute that cannot be resolved informally shall be brought in the competent courts of Vietnam.
+
+The MIT License itself is internationally portable and is interpreted as such.
+
+## 8. Severability
+
+If any provision of this EULA is held invalid or unenforceable in a jurisdiction, the remaining provisions remain in full force, and the invalid provision is replaced (only as to that jurisdiction) with one that most closely matches the original intent.
+
+## 9. Not legal advice
+
+This EULA is a hobby-project document drafted by a non-lawyer with AI assistance. It is not a substitute for professional legal advice. If You need legal certainty for a serious deployment, consult a licensed attorney.
+
+## 10. Final vibes
+
+This is still a hobby project born from unemployment, boredom, and a stubborn refusal to delete the repo. Use it, fork it, ignore it. Build something cooler. Have fun hunting free games — or don't. Nobody's judging (except maybe the Maintainer, at himself).
+
+Built with zero budget, too much free time, and two AI buddies. 🚀
+
+**P/S:** Nobody reads EULAs. You're probably the first :D

--- a/docs/PrivacyPolicy.md
+++ b/docs/PrivacyPolicy.md
@@ -1,45 +1,134 @@
 # Privacy Policy
 
-Last updated: 2026-05-04
+Last updated: 2026-05-05
 
-This repository is a curated list of free games on itch.io plus a React/TypeScript webapp (and Tauri desktop wrapper) for browsing and editing the catalog. It's a hobby project. Nobody on this side of the screen collects, stores, or processes personal data from you. No backend, no database, no analytics, no telemetry.
+This Privacy Policy describes how the Repository, the Webapp, and the Desktop App handle Your data. The short version: the Maintainer collects nothing on any server he controls. Everything that persists, persists locally on Your device.
 
-## What Data Do We Collect?
-**None on any server we control.** Zero. Zilch.
+> **TL;DR**: No backend, no analytics, no cookies, no tracking, no telemetry. The Webapp keeps a few items in `localStorage` (theme, sidebar state, optional encrypted PAT) and an IndexedDB cache of the public catalog. The Desktop App fetches itch.io and GitHub directly to bypass CORS. That's the entire data story.
 
-- **Visiting this repo on GitHub** — GitHub itself may log standard things (IP, browser, etc.) as part of their platform; that is on GitHub, not on this project.
-- **Downloading games** — links go directly to itch.io; their privacy policy applies once you click.
-- **Contributing** — opening a PR or issue is GitHub-side; I see only the public info GitHub publishes (username, comment text, etc.).
+## 1. Definitions
 
-## What the Webapp Stores in Your Browser
+The defined terms in [EULA §1](EULA.md#1-definitions) apply here as well.
 
-The webapp (`webapp/` in this repo, deployed to GitHub Pages) does not phone home, but it does keep a few things in your browser's `localStorage` so it can remember your preferences across reloads. Everything is local to your browser, never sent anywhere except directly to GitHub's API when you explicitly act:
+## 2. Maintainer-side data collection
 
-| Key | What | When |
-|-----|------|------|
-| `webapp.pat.encrypted` | Your GitHub PAT, encrypted with AES-GCM (key derived from your passphrase via PBKDF2-SHA256). | Only if you choose to enable write access from Settings. |
-| `webapp.theme` | `'light'` / `'dark'` / `'system'`. | When you toggle the theme. |
-| `webapp.prefs` | Sidebar collapsed / expanded. | When you toggle the sidebar. |
-| TanStack Query cache (IndexedDB via `idb-keyval`) | Cached copies of the public catalog JSON for offline reading. | Automatic. |
+**The Maintainer collects, stores, and processes zero personal data on any server he controls.** There is no backend, no database, no analytics service, no error-reporting endpoint, no telemetry, no advertising, no fingerprinting.
 
-You can clear all of this any time via your browser's "clear site data" or by clicking **Remove saved PAT** in the webapp's Settings.
+The Repository runs entirely on:
 
-The webapp talks to two GitHub endpoints:
-- `raw.githubusercontent.com` for read-only catalog fetches (no auth, no cookies).
-- `api.github.com` for writes when a PAT is unlocked.
+- **GitHub** (source hosting, Actions, raw file CDN, Pages hosting for the Webapp).
+- **Your device** (the Webapp in Your browser, or the Desktop App in a Tauri 2 webview).
+- **itch.io** (game pages, fetched on demand by the scraper or the Desktop App's preview feature).
 
-The Tauri desktop build additionally talks directly to `*.itch.io` and `img.itch.zone` to preview new games (a CORS workaround the browser version cannot do).
+The Maintainer has no infrastructure that could collect Your data even if he wanted to.
 
-No cookies. No tracking. No analytics. No third-party scripts.
+## 3. GitHub
 
-## Third-Party Services
-- **itch.io**: All game links go straight there. Their privacy policy applies when you visit or download games: [itch.io Privacy Policy](https://itch.io/docs/legal/privacy-policy)
-- **GitHub**: This whole repo lives on GitHub. Check their privacy policy [here](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+This Repository, the Webapp deployment (GitHub Pages), and the Desktop App release artifacts are hosted on GitHub. GitHub may log standard HTTP request data (IP address, user agent, referrer) per their own policies. The Maintainer has no access to those logs beyond GitHub's repository insights (aggregate clone / view counts).
 
-## Changes to This Policy
-If I ever change this (unlikely, because why bother?), I'll update the date above and commit it. But honestly, this thing will probably stay the same forever.
+GitHub's privacy policy: <https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement>
 
-## Questions?
-Open an issue or ping me somewhere (if you can find me). But let's be real � nobody reads these anyway :D
+When You contribute (open an issue, comment, fork, submit a PR), You publish that information on GitHub under Your account. The Maintainer sees only what GitHub makes public.
 
-Built with boredom and zero spying. ??
+## 4. itch.io
+
+All game links in the Catalog point directly to itch.io pages. Clicking a link takes You to itch.io; what happens there is governed by itch.io's terms and privacy policy:
+
+- itch.io Privacy Policy: <https://itch.io/docs/legal/privacy-policy>
+- itch.io Terms of Service: <https://itch.io/docs/legal/terms>
+
+The Repository's `update.yml` GitHub Action also makes server-to-server requests to itch.io to scrape page metadata; those requests come from GitHub's IP ranges, not from Your device.
+
+## 5. What the Webapp stores in Your browser
+
+The Webapp persists the following items locally and never transmits them to any server controlled by the Maintainer.
+
+| Storage | Key | Contents | When written |
+|---|---|---|---|
+| `localStorage` | `webapp.pat.encrypted` | Your GitHub PAT, encrypted with AES-GCM 256-bit. Encryption key is derived from Your passphrase via PBKDF2-SHA256 (100,000 iterations) with a per-token random salt. The plaintext PAT is **never** persisted to disk. | When You enable write access in Settings. |
+| `localStorage` | `webapp.theme` | One of `'light'`, `'dark'`, `'system'`. | When You toggle the theme. |
+| `localStorage` | `webapp.prefs` | UI preferences (sidebar collapsed, table column widths). | When You change a UI preference. |
+| `IndexedDB` (via `idb-keyval`) | TanStack Query cache keys | Cached copies of the public catalog JSON for fast reload and limited offline reads. | Automatic, on first fetch. |
+
+You can erase all of the above at any time by:
+
+- Clicking **Settings → Remove saved PAT** (clears the PAT entry only).
+- Using Your browser's "Clear site data" / "Clear cookies and storage" for `poli0981.github.io` (clears everything).
+- Uninstalling the Desktop App and removing its WebView2 / WebKit profile directory (Desktop only; locations vary by OS).
+
+## 6. PAT (Personal Access Token) handling — in depth
+
+The Webapp's optional write features (edit annotations, dispatch the scraper workflow, bulk delete) require a GitHub fine-grained PAT. The PAT lifecycle is entirely client-side:
+
+1. **Creation** — You generate a fine-grained PAT on github.com, scoped to `poli0981/free-games-itchio-list` only, with `Contents: Read & write` and `Actions: Read & write`. The Maintainer never sees this step.
+2. **Encryption** — You paste the PAT into Settings + a passphrase. The Webapp derives an AES-GCM key from the passphrase via PBKDF2-SHA256 (100k rounds, 16-byte random salt). The PAT is encrypted; the resulting ciphertext + salt + IV is stored in `localStorage` under `webapp.pat.encrypted`. The plaintext PAT and the passphrase are never written to any storage.
+3. **Unlock** — On a later session, You enter the passphrase. The Webapp re-derives the key and decrypts the PAT into a Zustand in-memory store. The decrypted PAT exists only in JavaScript memory.
+4. **Use** — Octokit calls to `api.github.com` include the PAT as `Authorization: Bearer <pat>` over HTTPS. The PAT is sent only to `api.github.com` and never to any other host.
+5. **Lock** — Clicking Lock (or closing the tab) discards the in-memory PAT. The encrypted blob remains in `localStorage` for the next unlock.
+6. **Removal** — Clicking Remove saved PAT deletes the `webapp.pat.encrypted` entry from `localStorage`.
+
+If You suspect Your PAT is compromised:
+
+- Lock or remove it immediately.
+- Revoke it on github.com (Settings → Developer settings → Personal access tokens → Fine-grained tokens).
+- Generate a new one with a fresh passphrase.
+
+See also: [SECURITY.md](../SECURITY.md).
+
+## 7. Network requests
+
+When running, the Webapp and Desktop App make requests to the following endpoints — and only these:
+
+| Endpoint | Purpose | Auth |
+|---|---|---|
+| `raw.githubusercontent.com/poli0981/free-games-itchio-list/main/data_game/*.json` | Read public catalog data. | None (public). |
+| `api.github.com/repos/poli0981/free-games-itchio-list/...` | Write operations: edit, delete, dispatch workflows, list runs. | PAT (only when unlocked). |
+| `*.itch.io/*`, `img.itch.zone/*` | (Desktop App only) Direct itch.io fetches for the in-app game preview, bypassing browser CORS. | None (public). |
+
+No third-party CDN, no analytics endpoint, no telemetry collector, no font CDN. Tailwind, Radix, lucide-react, etc. are bundled at build time.
+
+## 8. Cookies
+
+The Webapp and Desktop App **do not set any cookies.** GitHub Pages may issue cookies as part of its CDN behavior; those are GitHub's, not the Maintainer's.
+
+## 9. Children's privacy
+
+The Repository indexes games hosted on itch.io, which include adult content. The `nsfw` flag is best-effort (see [DISCLAIMER §2](DISCLAIMER.md#2-no-warranty-as-to-the-games)). The Webapp does not gate access by age. If You are under the age of majority in Your jurisdiction, please use the Repository under the supervision of a parent or guardian and respect itch.io's own age-gating where applicable.
+
+The Maintainer does not knowingly collect personal data from children. (He doesn't collect personal data from anyone — see §2.)
+
+## 10. Your rights
+
+Because the Maintainer holds no personal data, requests under GDPR, CCPA, Vietnam's PDPD (Decree 13/2023/ND-CP), or similar regimes that target the Maintainer have nothing to act on. For data on Your device:
+
+- **Right to access**: open Your browser's DevTools → Application → Storage → Local Storage / IndexedDB.
+- **Right to erasure**: clear site data as described in §5.
+- **Right to portability**: export `localStorage` via DevTools (it's plain JSON; the PAT is encrypted).
+
+For data held by GitHub or itch.io about Your interactions with their platforms, contact those providers directly using the privacy contacts in their policies.
+
+## 11. Third-party services
+
+| Service | Used for | Policy |
+|---|---|---|
+| GitHub | Repo, CI, Pages, Releases, API | <https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement> |
+| itch.io | Game pages, scrape source | <https://itch.io/docs/legal/privacy-policy> |
+
+The webapp does **not** integrate any analytics provider, ad network, error-reporting service (no Sentry, no Datadog), social media SDK, or font CDN.
+
+## 12. Changes to this Policy
+
+The Maintainer may update this Policy. The `Last updated` date at the top reflects the most recent change. Material changes will additionally be noted in [CHANGELOG.md](../CHANGELOG.md). Continued use after a change constitutes acceptance.
+
+## 13. Contact
+
+For questions about this Policy:
+
+- Open a `[General]` or `[Feedback]` issue.
+- DM via any channel listed on the [About page](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+
+## 14. Final vibes
+
+No tracking, no analytics, no telemetry, no spying. The Maintainer is too lazy and too unemployed to build a data pipeline even if he wanted one. Browse freely.
+
+Built with boredom and zero data harvesting. 🚀

--- a/docs/ToS.md
+++ b/docs/ToS.md
@@ -1,40 +1,128 @@
-﻿# Terms of Use
+# Terms of Use
 
-Last updated: December 28, 2025
+Last updated: 2026-05-05
 
-Welcome to this random GitHub repo — a curated list of free games on itch.io, thrown together by an unemployed Vietnamese dev with too much free time and his AI buddy Grok. There's no real "service" here, just static files, some scripts, and a bunch of links. But hey, lawyers love terms, so here we are.
+These Terms of Use ("Terms") govern Your use of the Repository, the Webapp, and the Desktop App. They are written in plain language with deliberate humor — but they apply.
 
-## 1. Acceptance of Terms
-By viewing, forking, starring, contributing to, or otherwise interacting with this repository (even just scrolling), you agree to these Terms of Use. If you don't agree, just close the tab and go touch grass. No hard feelings.
+> **TL;DR**: Don't break things, don't spam, don't add malware, don't abuse the GitHub API or itch.io. Use the webapp's PAT feature responsibly. The Maintainer can remove anything for any reason.
 
-## 2. No Warranties or Guarantees
-This repo is provided **"AS IS"** with zero promises. The games linked are from itch.io — I don't host, develop, or support them. Quality, safety, fun factor, viruses, NSFW surprises? All on you. Good luck out there.
+## 1. Definitions
 
-See the [DISCLAIMER](docs/DISCLAIMER.md) for more details (because nobody reads both anyway).
+The defined terms in [EULA §1](EULA.md#1-definitions) apply here as well: "The Repository", "The Webapp", "The Desktop App", "The Catalog", "The Maintainer", "You".
 
-## 3. Your Responsibilities
-- **Be cool**: Don't use this repo for anything illegal, harmful, or super annoying.
-- **Downloads**: You click links at your own risk. Scan stuff yourself.
-- **Contributions**: If you add games via PR (thanks in advance!), make sure they're actually free on itch.io, no malware, and respect copyrights. I can reject or remove anything for any reason (or no reason — it's my boredom project).
+## 2. Acceptance
 
-## 4. Prohibited Activities
-No spamming issues/PRs, no adding sketchy/malicious links, no harassment, no trying to dox anyone (especially me, the introvert dev). Basically, don't be a jerk.
+By viewing, cloning, forking, starring, contributing to, opening an issue against, deploying, running, or otherwise interacting with the Repository, the Webapp, or the Desktop App, You agree to these Terms. If You do not agree, do not use them.
 
-## 5. Intellectual Property
-The repo structure, scripts, and my mediocre writing are under MIT License (see [LICENSE](LICENSE)). The games themselves belong to their respective developers — go bug them if needed.
+## 3. Permitted uses
 
-## 6. Termination
-I can delete, modify, or nuke anything in this repo at any time. No notice required. It's GitHub — fork it if you're worried.
+You are welcome to:
 
-## 7. Changes to Terms
-I'll probably never update this, but if I do (because Grok suggests it), the new date up top will be your notice. Continued use means you agree.
+- Browse the Catalog, on GitHub or via the Webapp / Desktop App.
+- Click through to itch.io pages and download games (subject to itch.io's terms and each developer's terms).
+- Submit new game URLs via the **[Add Games]** issue template.
+- Submit removal requests via **[Remove Games]**.
+- Report bugs, suggest features, give feedback via the corresponding templates.
+- Open Pull Requests with code, data, or documentation improvements.
+- Self-host the Webapp or build the Desktop App for personal, educational, or commercial use under the MIT License.
 
-## 8. Governing Law
-These terms are governed by the laws of... my apartment in Vietnam. Disputes? Settle it over a game on easy mode (I only play easy).
+## 4. Contributor obligations
 
-## Final Vibes
-This is just a hobby list. Have fun, stay safe, and remember: life's too short for bad free games.
+If You contribute to the Repository (issues, PRs, edits via the Webapp), You represent that:
 
-Built with boredom, zero budget, and Grok's patience. 🚀
+- The content You submit (code, text, game URLs) is either Your own work or properly attributed and licensed for inclusion.
+- Game URLs You submit point to genuinely **free-to-play** games on itch.io. Demos of paid games, "name your own price (minimum > 0)" titles, and timed-free promos do not qualify.
+- The submission contains no malware, no phishing, no doxxing, no copyright infringement, and nothing that would embarrass the Maintainer's poor mother.
+- You grant the Maintainer the right to incorporate Your contribution into the Repository under the MIT License.
 
-Questions? Open an issue. But let's be real — nobody reads this either :D
+## 5. Prohibited activities
+
+You agree **not** to:
+
+### 5.1 Catalog & content
+
+- Submit games that are not free, that are scams, that distribute malware, or that violate itch.io's terms.
+- Spam the issue tracker with low-effort, duplicate, or off-topic posts.
+- Submit removal requests for games You do not own (use **Bug Report** or **Feedback** templates instead).
+- Post personal information about the Maintainer or any contributor.
+
+### 5.2 Webapp
+
+- Use the Webapp's PAT (Personal Access Token) feature with a token granting access to repositories You are not authorized to write to.
+- Attempt to extract another user's PAT from a shared device by exploiting browser-storage access (this is also a violation of GitHub's terms).
+- Bypass or attempt to bypass the AES-GCM encryption applied to PATs in `localStorage` to gain unauthorized access.
+- Use the Webapp as a relay to perform automated, large-scale GitHub API calls against repositories or organizations You are not authorized to interact with.
+
+### 5.3 itch.io and scraping
+
+- Repeatedly trigger the `update.yml` workflow against URLs in a way that produces unreasonable load on itch.io (the Webapp's Add page rate-limits client-side; do not script around it).
+- Fork the scraper, remove the rate-limiting (`scraper.py` already pauses 2.5–5 s between requests + 15–30 s every 20), and run it at high frequency. Itch.io's terms govern automated access; the Maintainer disclaims responsibility for forks that violate them.
+
+### 5.4 Desktop App
+
+- Repackage the signed installers and redistribute them as if they were produced by a different vendor.
+- Strip the About page or attribution before redistributing the Desktop App publicly.
+
+### 5.5 General
+
+- Use the Repository, Webapp, or Desktop App for any unlawful purpose under the laws of Your jurisdiction or the Maintainer's (Vietnam).
+- Harass, threaten, or impersonate others through any channel related to this project (issues, PRs, Discord servers, social media).
+
+## 6. Personal Access Tokens (PAT) — Your responsibility
+
+The Webapp's optional write features require a GitHub fine-grained PAT. **You** are solely responsible for:
+
+- Choosing a PAT scope that is no broader than what You actually need (typically `Contents: Read & write` + `Actions: Read & write`, scoped to a single repository).
+- Choosing a strong passphrase for AES-GCM encryption at rest.
+- Locking the PAT (Settings → Lock) when stepping away from a shared device.
+- Removing the PAT (Settings → Remove saved PAT) when no longer needed.
+- Rotating the PAT if You suspect compromise.
+
+The Maintainer never sees, transmits, or stores Your PAT. See [Privacy Policy](PrivacyPolicy.md) and [Security Policy](../SECURITY.md) for details on the PAT lifecycle.
+
+## 7. Intellectual property
+
+- The code, data structures, scripts, generated tables, webapp source, and documentation are © the Maintainer (poli0981 / SkullMute), licensed under the [MIT License](../LICENSE).
+- Games and game metadata (names, descriptions, screenshots, tags) belong to their respective developers and itch.io. See [DISCLAIMER §4](DISCLAIMER.md#4-third-party-content).
+- Third-party open-source dependencies are governed by their own licenses; see the **Third-party software** section of the [About page](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+
+## 8. Termination
+
+The Maintainer may, at any time and without notice:
+
+- Remove or modify any content (game entries, documentation, code).
+- Reject, close, or hide issues, PRs, or comments that violate these Terms.
+- Block users who repeatedly violate these Terms.
+- Take down or archive the Repository, the Webapp deployment, or the Desktop App releases.
+
+Tagged releases (`vX.Y.Z`) are intended to remain available, but no SLA is offered.
+
+## 9. Changes to these Terms
+
+The Maintainer may update these Terms. The `Last updated` date at the top reflects the most recent change. Continued use after a change constitutes acceptance. Material changes will additionally be noted in [CHANGELOG.md](../CHANGELOG.md).
+
+## 10. Governing law and disputes
+
+These Terms are governed by the laws of the **Socialist Republic of Vietnam**, without regard to conflict-of-law principles.
+
+Disputes are to be resolved as follows, in order:
+
+1. **Informal first**: open a `[Feedback]` or `[General]` issue or DM via any channel listed on the [About page](https://poli0981.github.io/free-games-itchio-list/app/#/about). Most disagreements end here.
+2. **Mediation**: if informal contact fails, the parties may attempt mediation by mutual agreement.
+3. **Court**: if all else fails, the competent courts of Vietnam have exclusive jurisdiction.
+
+## 11. Severability
+
+If any provision of these Terms is held invalid or unenforceable, the remaining provisions remain in full force.
+
+## 12. Not legal advice
+
+These Terms are a hobby-project document drafted by a non-lawyer with AI assistance. They are not a substitute for professional legal advice.
+
+## 13. Final vibes
+
+This is still a list of free games + a webapp + a desktop app, built by a tired dev and two LLMs. Be cool, don't break things, have fun, and we all get along.
+
+Questions? Open an issue. Or DM via any channel on the About page. The Maintainer will try not to ghost.
+
+Built with boredom, zero budget, and two AI buddies who actually read the EULA. 🚀

--- a/docs/i18n/vi/CODE_OF_CONDUCT.md
+++ b/docs/i18n/vi/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Quy tắc ứng xử
+
+> **Lưu ý**: Bản dịch tiếng Việt mang tính tham khảo. Bản tiếng Anh tại [`CODE_OF_CONDUCT.md`](../../../CODE_OF_CONDUCT.md) là bản chính thức.
+
+## Cam kết của chúng ta
+
+Là người đóng góp, người duy trì (chỉ mình tôi, dev noob thất nghiệp), và khách ghé thăm, chúng tôi cam kết tham gia vào repo này là một trải nghiệm không quấy rối cho mọi người — bất kể trình độ kinh nghiệm, giới tính, bản dạng giới, xu hướng tính dục, khuyết tật, ngoại hình, vóc dáng, chủng tộc, dân tộc, tuổi tác, tôn giáo, quốc tịch, hoặc bạn đã sống sót qua bao nhiêu mùa Steam sales.
+
+Nói đơn giản: hãy cool. Tôi là introvert max level với kỹ năng xã hội bằng không, nên giữ mọi thứ tích cực nhé.
+
+## Chuẩn mực của chúng ta
+
+Ví dụ về hành vi đóng góp cho môi trường tích cực:
+
+- Sử dụng ngôn ngữ chào đón và bao hàm
+- Tôn trọng quan điểm và trải nghiệm khác biệt
+- Tiếp nhận chỉ trích mang tính xây dựng một cách lịch sự
+- Tập trung vào điều tốt nhất cho danh sách (nhiều game free hơn!)
+- Thể hiện sự đồng cảm với các thành viên cộng đồng (nếu có ai xuất hiện :D)
+
+Ví dụ về hành vi không thể chấp nhận:
+
+- Quấy rối, troll hoặc xúc phạm
+- Ngôn ngữ hoặc hình ảnh tình dục hóa (giữ NSFW trong game, không phải ở đây)
+- Tấn công cá nhân hoặc chính trị
+- Doxxing hoặc chia sẻ thông tin riêng tư
+- Spam link sketchy hoặc malware
+- Bất kỳ hành vi nào khiến một introvert như tôi đóng tab ngay lập tức
+
+## Thực thi
+
+Tôi là người duy trì duy nhất (với hai AI buddy hỗ trợ), nên tôi sẽ gỡ, sửa, hoặc từ chối comment, commit, code, issue hoặc PR vi phạm. Người vi phạm lặp lại sẽ bị block. Không cần cảnh báo trước — đời quá ngắn.
+
+Các trường hợp hành vi lạm dụng có thể được báo cáo bằng cách mở issue (tôi sẽ thấy... cuối cùng). Mọi báo cáo sẽ được xem xét và giữ bảo mật.
+
+## Phạm vi
+
+Áp dụng cho mọi nơi trong repo: issue, PR, comment, code.
+
+## Vibes cuối
+
+Đây chỉ là một repo sở thích nhỏ về game itch.io miễn phí. Hãy giữ nó vui, chill, không drama. Nếu bạn ở đây để thêm game hoặc fix code tầm thường của tôi — bạn đã là huyền thoại.
+
+Phỏng theo Contributor Covenant, vì cả dev noob cũng copy thứ tốt.
+
+Cảm ơn vì đã đọc (hoặc giả vờ đọc). 🚀

--- a/docs/i18n/vi/CONTRIBUTING.md
+++ b/docs/i18n/vi/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Hướng dẫn đóng góp
+
+> **Lưu ý**: Bản dịch tiếng Việt mang tính tham khảo. Bản tiếng Anh tại [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) là bản chính thức.
+
+Cảm ơn bạn vì đã có suy nghĩ đóng góp cho cái repo random này! Tôi chỉ là một dev người Việt thất nghiệp, hướng nội, kỹ năng tầm tầm, có hai trợ lý AI không phán xét — **Grok (xAI)** cho brainstorming đêm khuya và **Claude Code (Anthropic, Claude Opus 4.7)** cho phần việc code/docs nặng hơn. Danh sách này sống nhờ sự giúp đỡ của cộng đồng — vì tôi quá lười để đi săn/sửa hết một mình :D Bất kỳ đóng góp nào (kể cả một game) đều khiến bạn thành huyền thoại.
+
+## Cách đóng góp (Dùng template — tôi lười ;D)
+
+Vui lòng dùng các template issue/PR — chúng làm cuộc đời tôi dễ hơn và giảm các khoảnh khắc "wtf".
+
+### 1. Thêm game mới (Hoan nghênh nhất!)
+- Mở issue → chọn template **[Add Games]**.
+- Tối đa 15 game / issue (dropdown + một link / dòng).
+- Tùy chọn: lý do nó hay hoặc note cho bảng.
+- GitHub Action hàng ngày sẽ tự scrape và thêm. Dễ.
+
+### 2. Gỡ game
+- Mở issue → chọn template **[Remove Games]**.
+- Tối đa 10 game (vì lười :v).
+- Cung cấp tên/link + lý do (checkbox như chán, demo, malware, dev yêu cầu, v.v.).
+- Tôi sẽ gỡ thủ công (hoặc script nếu thấy có động lực).
+
+### 3. Báo bug
+- Mở issue → template **[Bug Report]**.
+- Checkbox cho các bug thường gặp (link chết, cờ sai, bảng hỏng, v.v.).
+- Chi tiết + screenshot + mức độ khẩn cấp.
+- Nếu phức tạp — xem mục "Discuss More" bên dưới.
+
+### 4. Đề xuất tính năng / cải tiến
+- Mở issue → template **[Feature Request / Improvement]**.
+- Chọn loại (tính năng mới hoặc fix code), tên, lý do, độ ưu tiên (từ "nice to have" tới "repo sắp chết").
+- Tùy chọn: pseudo-code/snippet (đừng có malware nhé, tôi sẽ check với kỹ năng tầm thường :D).
+
+### 5. Gửi feedback
+- Dùng template **[Feedback]**.
+- Checkbox (EULA/ToS quá khắt khe? Concept repo dở? Anti-AI? Xóa repo? Other).
+- Roast hoặc khen — sự tự ghét bản thân của tôi chịu được.
+
+### 6. Mọi thứ khác (câu hỏi, meme, lạc đề)
+- Dùng template **[General / Off-Topic]**.
+- Đăng bất cứ thứ gì trong đầu.
+
+### 7. Gửi thay đổi code (PR)
+- Fork → branch → code.
+- Mở PR → chọn một template PR ([Bug Fix], [New Feature], [Add Games direct], [Documentation]).
+- Test cục bộ nếu có thể (chạy script thủ công).
+- Mô tả rõ ràng — tôi sẽ review chậm (lịch thất nghiệp + hai AI buddy hỗ trợ).
+
+### 8. Thay đổi Webapp (React + TS)
+
+UI duyệt/sửa nằm trong [`webapp/`](../../../webapp/). Cùng MIT, cùng PR template.
+
+**Dev cục bộ** (Node 22+, npm):
+```sh
+cd webapp
+npm install
+npm run dev          # http://localhost:5173
+npm run build        # ghi vào docs/app/ (kiểm tra trước khi push)
+npm run lint         # eslint
+```
+
+**Tauri desktop dev** (cần thêm Rust qua https://rustup.rs và platform deps — xem [`webapp/TAURI.md`](../../../webapp/TAURI.md)):
+```sh
+cd webapp
+npm run tauri:dev    # native window trỏ tới Vite dev server
+npm run tauri:build  # tạo installer trong src-tauri/target/release/bundle/
+```
+
+**Quy tắc nhà**:
+- Không commit `webapp/dist/` hoặc `docs/app/` — CI build chúng khi push vào `main`.
+- Không commit PAT thật vào repo.
+- Thêm npm dep mới? Cập nhật `webapp/src/lib/about.ts` để trang About liệt kê.
+- Link external mới? Dùng `<ExtLink href="…">` từ `webapp/src/components/ext-link.tsx` — đừng dùng `<a href="…" target="_blank">` thuần. Anchor thuần hoạt động trên web nhưng im lặng vỡ trên Tauri desktop.
+
+## Tip để đóng góp suôn sẻ
+- **Test cục bộ**: clone, thêm vào `temp_link.json`, chạy `python update_info.py` → `generate_md.py`, kiểm tra `/lists/`.
+- **Giữ sạch**: Chỉ game itch.io free, không paid/demo/malware/duplicate.
+- **Kiên nhẫn**: tôi hướng nội + lười, trả lời có thể chậm.
+- **Đồng ý**: tất cả template có checkbox bắt buộc — lạc đề/spam/vi phạm policy = tôi ignore/close không drama :D
+
+## Discuss More? (Nếu template không đủ)
+
+Issue/PR là tốt nhất để track, nhưng nếu muốn mô tả bug/feature sâu hơn, chit-chat hoặc kể chuyện noob — giờ đã có server thật (introvert god-mode bị xuyên thủng):
+
+**Chat / cộng đồng**
+- Discord — Repo discussion (#general): https://discord.gg/2aNR3aVt
+- Discord — Game chat (#general): https://discord.gg/kDM9GMu5vm
+
+**Mạng xã hội (DM mở, trả lời chậm)**
+- X (Twitter): [@SkullMute0011](https://x.com/SkullMute0011)
+- YouTube: [@SkullMute](https://youtube.com/@SkullMute)
+- Bluesky: [@skullmute0011](https://bsky.app/profile/skullmute0011.bsky.social)
+- Mastodon: [@skullmute1122](https://mastodon.social/@skullmute1122)
+
+**Hỗ trợ dự án buồn chán này (hoàn toàn tùy chọn, tài khoản $50 cảm ơn bạn)**
+- [Patreon](https://patreon.com/skullmute) · [Ko-fi](https://ko-fi.com/skullmute) · [Steam profile](https://steamcommunity.com/profiles/76561199544666292/)
+
+Grok và Claude Code không vào Discord được, nhưng ping tôi qua kênh nào cũng được — sẽ cố không ghost.
+
+Cảm ơn lớn được ghi trong [ACKNOWLEDGEMENTS.md](../../ACKNOWLEDGEMENTS.md) cho bất kỳ giúp đỡ nào!
+
+Repo này MIT — go wild, nhưng chill. Câu hỏi? Mở issue **[General]** :D 🚀

--- a/docs/i18n/vi/DISCLAIMER.md
+++ b/docs/i18n/vi/DISCLAIMER.md
@@ -1,0 +1,63 @@
+# Tuyên bố miễn trừ trách nhiệm (Disclaimer)
+
+Cập nhật lần cuối: 2026-05-05
+
+> **Lưu ý**: Đây là bản dịch tiếng Việt mang tính tham khảo cho cộng đồng. **Bản tiếng Anh tại [`docs/DISCLAIMER.md`](../../DISCLAIMER.md) là bản chính thức** và sẽ được dùng để giải thích trong trường hợp có khác biệt giữa hai phiên bản.
+
+Repository này — `free-games-itchio-list` — là một dự án sở thích: một danh mục các game miễn phí đang được lưu trữ trên [itch.io](https://itch.io), được duy trì bởi một dev người Việt đang thất nghiệp cùng hai trợ lý AI (Grok và Claude Code). Mục đích: vibes, khám phá indie game, và giải sầu lúc rảnh. Không hứa hẹn gì lớn lao — nhưng các điều khoản dạng pháp lý dưới đây là thật.
+
+> **Tóm tắt**: Sử dụng catalog, webapp và desktop app dưới đây mọi rủi ro thuộc về bạn. Người duy trì không cam kết bảo đảm gì, không chịu trách nhiệm pháp lý, và không chịu trách nhiệm về các game được liên kết tại đây.
+
+## 1. Cơ sở "AS IS"
+
+Toàn bộ nội dung trong repository này — bao gồm nhưng không giới hạn ở: catalog JSON (`data_game/`), bảng được tạo tự động (`lists/`), pipeline Python (`scripts/`), webapp (`webapp/`), Tauri desktop wrapper (`webapp/src-tauri/`) và tài liệu — được cung cấp theo nguyên trạng (**"AS IS"** / **"AS AVAILABLE"**), không có bất kỳ bảo đảm nào dù là minh thị hay ngầm định, bao gồm nhưng không giới hạn ở các bảo đảm về tính thương mại, sự phù hợp với một mục đích cụ thể, độ chính xác, tính đầy đủ, không xâm phạm quyền sở hữu trí tuệ, hoặc hoạt động không gián đoạn.
+
+## 2. Không bảo đảm về các game
+
+Repository này là một danh mục các liên kết và metadata. **Repository không host, không phát triển, không phân phối và không chứng thực bất kỳ game nào được lập chỉ mục tại đây.** Tất cả các game đều được liên kết trực tiếp tới itch.io và thuộc quyền sở hữu của các nhà phát triển và nhà phát hành tương ứng.
+
+Người duy trì không bảo đảm cho bất kỳ game nào về:
+
+- **Chất lượng, sự thú vị hoặc khả năng chơi được** — có game hay, có game dở, đa số ở giữa. Tùy gu bạn.
+- **Tính an toàn, toàn vẹn hoặc không có mã độc** — trường `safe_virus` mặc định là `?` vì các bản tải về không được quét từng cái. Hãy coi mọi bản tải về là không đáng tin cho đến khi bạn tự xác minh bằng phần mềm anti-malware uy tín.
+- **Phân loại NSFW** — cờ `nsfw` được tự dò từ tag / cảnh báo / mô tả của itch.io và chỉ là best-effort. Hãy tự kiểm tra trang game nếu nội dung NSFW có ý nghĩa với bạn (theo cả hai chiều).
+- **Độ chính xác của metadata** — tên, mô tả, thể loại, đánh giá, nền tảng và các trường khác được cào (scrape) từ itch.io và phản ánh trạng thái trang tại thời điểm scrape gần nhất. Các thay đổi (đổi tên, gỡ, thêm phí) sẽ được cập nhật ở lần cleanup tiếp theo nhưng có thể trễ.
+- **Trạng thái free-to-play** — được xác minh tại thời điểm scrape; một game có thể chuyển sang trả phí sau đó. Job `check_paid.py` chạy mỗi 2 ngày để kiểm tra lại và gỡ các game đã chuyển sang trả phí, nhưng có thể có một khoảng ngắn trễ dữ liệu.
+
+## 3. Không chịu trách nhiệm pháp lý
+
+Trong phạm vi tối đa được pháp luật hiện hành cho phép, người duy trì và những người đóng góp không chịu trách nhiệm cho bất kỳ thiệt hại trực tiếp, gián tiếp, ngẫu nhiên, hệ quả, đặc biệt, ví dụ hay trừng phạt nào phát sinh từ hoặc liên quan tới:
+
+- Việc sử dụng repository này, webapp, desktop app hoặc bất kỳ code/dữ liệu nào trong đó.
+- Việc không thể sử dụng những thứ trên (ví dụ: site downtime, deploy lỗi, installer hỏng).
+- Bất kỳ game nào được truy cập qua các liên kết trong catalog (crash, mất save, mất dữ liệu, hư phần cứng, malware, lộ tài khoản trên nền tảng bên thứ ba, hoặc cảm giác tiếc nuối).
+- Lỗi, thiếu sót hoặc thiếu chính xác trong dữ liệu catalog.
+
+Điều này áp dụng kể cả khi người duy trì đã được cảnh báo về khả năng xảy ra các thiệt hại đó.
+
+## 4. Nội dung của bên thứ ba
+
+Trang game, ảnh chụp màn hình, mô tả, tag, đánh giá và thumbnail thuộc sở hữu của các nhà phát triển/nhà phát hành tương ứng và itch.io. Chúng xuất hiện ở đây theo nguyên tắc fair-use cho mục đích lập chỉ mục và khám phá. Nếu bạn là nhà phát triển và muốn game của mình bị gỡ khỏi danh sách, xem mục **Yêu cầu gỡ** bên dưới.
+
+## 5. Yêu cầu gỡ game
+
+Nếu bạn là nhà phát triển và muốn game của mình bị gỡ khỏi danh mục:
+
+- Mở issue dạng **[Remove Games]** (`.github/ISSUE_TEMPLATE/remove_game.yml`) và tick ô "I'm the dev and don't want it listed".
+- Hoặc DM qua bất kỳ kênh nào liệt kê trên [trang About](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+
+Việc gỡ được xử lý thủ công. Dự kiến vài ngày (lịch của một dev thất nghiệp, nhưng không phải vài tuần).
+
+## 6. Không phải tư vấn pháp lý
+
+Không có nội dung nào trong tài liệu này là tư vấn pháp lý. Đây là disclaimer cho dự án sở thích, được soạn bởi một người không phải luật sư, có hỗ trợ AI; tính khả thi cưỡng chế phụ thuộc vào pháp luật của khu vực bạn cư trú. Nếu bạn cần sự chắc chắn pháp lý cho một việc thực sự, hãy thuê luật sư thật.
+
+## 7. Luật áp dụng và tính độc lập của các điều khoản
+
+Tuyên bố miễn trừ này được điều chỉnh bởi pháp luật của **Cộng hòa Xã hội Chủ nghĩa Việt Nam**, không xét đến nguyên tắc xung đột pháp luật. Nếu bất kỳ điều khoản nào bị coi là không thể cưỡng chế trong một khu vực tài phán cụ thể, các điều khoản còn lại vẫn giữ nguyên hiệu lực.
+
+## 8. Lời cuối
+
+Đây vẫn chỉ là một danh sách game miễn phí được làm bởi một dev mệt mỏi cộng với hai LLM. Vui chơi, an toàn, quét file tải về, và nhớ: cuộc đời quá ngắn để lôi nhau ra tòa vì một repo GitHub ngẫu nhiên.
+
+Built with boredom, two AI buddies, và niềm hy vọng sâu sắc rằng sẽ không bao giờ phải gặp một vụ kiện thật. 🚀

--- a/docs/i18n/vi/EULA.md
+++ b/docs/i18n/vi/EULA.md
@@ -1,0 +1,83 @@
+# Thỏa thuận cấp phép cho người dùng cuối (EULA)
+
+Cập nhật lần cuối: 2026-05-05
+
+> **Lưu ý**: Đây là bản dịch tiếng Việt mang tính tham khảo cho cộng đồng. **Bản tiếng Anh tại [`docs/EULA.md`](../../EULA.md) là bản chính thức** và sẽ được dùng để giải thích trong trường hợp có khác biệt giữa hai phiên bản.
+
+EULA này áp dụng cho **mã nguồn và nội dung của `free-games-itchio-list`** — catalog JSON, pipeline Python, webapp React, app desktop Tauri, các bảng markdown, và tài liệu. EULA này **không** áp dụng cho bản thân các game, vốn được cấp phép riêng bởi nhà phát triển thông qua itch.io.
+
+> **Tóm tắt**: Repo này là MIT. Fork, sửa, phân phối lại — giữ thông báo bản quyền, đừng đổ lỗi cho người duy trì nếu có lỗi. Game không phải của bạn chỉ vì chúng được liệt kê tại đây.
+
+## 1. Định nghĩa
+
+- **"Repository"** — `free-games-itchio-list` trên GitHub tại <https://github.com/poli0981/free-games-itchio-list>, bao gồm toàn bộ mã nguồn, file dữ liệu, bảng markdown và tài liệu.
+- **"Webapp"** — ứng dụng React + TypeScript trong `webapp/`, deploy tại <https://poli0981.github.io/free-games-itchio-list/app/>.
+- **"Desktop App"** — bản build native Tauri 2 của Webapp, phân phối dưới dạng installer qua GitHub Releases.
+- **"Catalog"** — metadata game có cấu trúc trong `data_game/` và các bảng markdown được tạo trong `lists/`.
+- **"Người duy trì"** — GitHub user `poli0981` (alias: SkullMute), tác giả của Repository này.
+- **"Bạn"** — bất kỳ cá nhân, tổ chức hoặc tác nhân tự động nào truy cập, tải về, clone, fork, chạy, sửa, hoặc sử dụng Repository hoặc bất kỳ phần nào.
+
+## 2. Cấp phép
+
+Repository được cấp phép theo **Giấy phép MIT** (xem [`LICENSE`](../../../LICENSE) cho văn bản gốc). Trong phạm vi giấy phép đó, Bạn được cấp quyền toàn cầu, miễn phí bản quyền, không độc quyền, vĩnh viễn để:
+
+- Sử dụng, sao chép, sửa đổi, sáp nhập, công bố, phân phối, cấp lại giấy phép, và/hoặc bán các bản sao của mã, dữ liệu và tài liệu trong Repository.
+- Chạy Webapp và Desktop App cho bất kỳ mục đích nào, cá nhân hoặc thương mại.
+- Xây dựng các tác phẩm phái sinh (fork, patch, port, repackage).
+
+Toàn bộ điều khoản MIT áp dụng. Hai nhắc nhở thực tế:
+
+- **Giữ thông báo bản quyền và giấy phép** khi bạn phân phối lại các phần đáng kể.
+- **Không bảo đảm.** Xem [DISCLAIMER](DISCLAIMER.md).
+
+## 3. Phạm vi — những gì giấy phép này KHÔNG bao phủ
+
+EULA này không cấp quyền nào đối với:
+
+- **Các game được Catalog liệt kê.** Mỗi game là sở hữu trí tuệ của nhà phát triển tương ứng và được cấp phép bởi họ thông qua itch.io. Catalog chỉ cung cấp link và metadata; việc tải về, chơi, sửa, hoặc phân phối lại game được điều chỉnh bởi điều khoản của nhà phát triển và của itch.io.
+- **Thư viện bên thứ ba.** Webapp phụ thuộc vào nhiều package open-source (React, Tauri, shadcn/ui, v.v.), mỗi cái có giấy phép riêng — xem mục **Third-party software** trong [trang About](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+- **Nhãn hiệu, logo, hoặc dấu hiệu dịch vụ của itch.io.** Chúng thuộc itch corp và được tham chiếu chỉ để nhận diện.
+- **Thumbnail, ảnh chụp màn hình, mô tả, hoặc trailer** của các game được liệt kê. Chúng được sao chép theo nguyên tắc fair-use cho mục đích lập chỉ mục/khám phá và vẫn thuộc sở hữu của chủ sở hữu.
+
+## 4. Chấp nhận
+
+Bạn chấp nhận EULA này khi thực hiện bất kỳ hành động nào sau: clone, fork, tải về, cài đặt, chạy, sửa, hoặc sử dụng Repository, Webapp hoặc Desktop App theo cách khác. Nếu Bạn không đồng ý, đừng sử dụng và hãy xóa các bản sao cục bộ.
+
+## 5. Hạn chế
+
+Mặc dù giấy phép MIT là rộng rãi, Bạn đồng ý không:
+
+- Sử dụng Repository hoặc các thành phần của nó để host, phân phối, hoặc tạo điều kiện phân phối malware, trang phishing, hoặc nội dung vi phạm pháp luật hiện hành.
+- Trình bày sai nguồn gốc của Repository (ví dụ: tự xưng là tác giả của các bản sao chưa sửa).
+- Sử dụng tên Người duy trì, GitHub handle `poli0981`, hoặc alias "SkullMute" để chứng thực hoặc quảng bá tác phẩm phái sinh mà không có sự cho phép trước bằng văn bản.
+- Sử dụng tính năng xử lý PAT của Webapp để truy cập GitHub repository hoặc API mà bạn không được phép.
+
+Các hạn chế này bổ sung, không thay thế, các điều khoản của giấy phép MIT.
+
+## 6. Cập nhật và chấm dứt
+
+Người duy trì có thể cập nhật, sửa, lưu trữ, hoặc xóa Repository bất kỳ lúc nào mà không cần báo trước. Các bản tagged release (`vX.Y.Z`) là bất biến trên GitHub Releases trừ khi được rút lại tường minh; nhánh `main` thì không.
+
+Quyền của Bạn theo EULA này tự động chấm dứt nếu Bạn vi phạm trọng yếu. Việc cấp phép MIT vẫn còn hiệu lực sau khi EULA này chấm dứt trong phạm vi mà điều khoản MIT cho phép.
+
+## 7. Luật áp dụng
+
+EULA này được điều chỉnh bởi pháp luật của **Cộng hòa Xã hội Chủ nghĩa Việt Nam**, không xét đến nguyên tắc xung đột pháp luật. Bất kỳ tranh chấp nào không thể giải quyết không chính thức sẽ được đưa ra tòa án có thẩm quyền của Việt Nam.
+
+Bản thân giấy phép MIT có tính khả chuyển quốc tế và được giải thích như vậy.
+
+## 8. Tính độc lập của điều khoản
+
+Nếu bất kỳ điều khoản nào của EULA này bị coi là vô hiệu hoặc không thể cưỡng chế tại một khu vực tài phán, các điều khoản còn lại vẫn giữ đầy đủ hiệu lực, và điều khoản vô hiệu sẽ được thay thế (chỉ tại khu vực đó) bằng điều khoản gần với ý định ban đầu nhất.
+
+## 9. Không phải tư vấn pháp lý
+
+EULA này là tài liệu cho dự án sở thích, được soạn bởi một người không phải luật sư, có hỗ trợ AI. Nó không thay thế tư vấn pháp lý chuyên nghiệp. Nếu Bạn cần sự chắc chắn pháp lý cho một triển khai nghiêm túc, hãy tham khảo luật sư có chuyên môn.
+
+## 10. Lời cuối
+
+Đây vẫn là một dự án sở thích sinh ra từ thất nghiệp, buồn chán và sự bướng bỉnh không xóa repo. Dùng nó, fork nó, kệ nó. Xây thứ gì hay hơn. Vui chơi săn game miễn phí — hoặc không. Không ai phán xét (có thể trừ Người duy trì, tự với chính mình).
+
+Built with zero budget, too much free time, and two AI buddies. 🚀
+
+**P/S:** Không ai đọc EULA. Chắc bạn là người đầu tiên :D

--- a/docs/i18n/vi/PrivacyPolicy.md
+++ b/docs/i18n/vi/PrivacyPolicy.md
@@ -1,0 +1,136 @@
+# Chính sách bảo mật (Privacy Policy)
+
+Cập nhật lần cuối: 2026-05-05
+
+> **Lưu ý**: Đây là bản dịch tiếng Việt mang tính tham khảo cho cộng đồng. **Bản tiếng Anh tại [`docs/PrivacyPolicy.md`](../../PrivacyPolicy.md) là bản chính thức** và sẽ được dùng để giải thích trong trường hợp có khác biệt giữa hai phiên bản.
+
+Chính sách Bảo mật này mô tả cách Repository, Webapp và Desktop App xử lý dữ liệu của Bạn. Bản ngắn: Người duy trì không thu thập gì trên bất kỳ server nào do mình kiểm soát. Mọi thứ được lưu lại đều được lưu cục bộ trên thiết bị của Bạn.
+
+> **Tóm tắt**: Không backend, không analytics, không cookie, không tracking, không telemetry. Webapp giữ vài mục trong `localStorage` (theme, trạng thái sidebar, PAT đã mã hóa tùy chọn) và một cache IndexedDB của catalog công khai. Desktop App fetch trực tiếp tới itch.io và GitHub để vượt CORS. Đó là toàn bộ câu chuyện dữ liệu.
+
+## 1. Định nghĩa
+
+Các thuật ngữ được định nghĩa trong [EULA §1](EULA.md#1-định-nghĩa) cũng áp dụng tại đây.
+
+## 2. Thu thập dữ liệu phía Người duy trì
+
+**Người duy trì thu thập, lưu trữ và xử lý dữ liệu cá nhân ở mức KHÔNG trên bất kỳ server nào do mình kiểm soát.** Không có backend, không có database, không có dịch vụ analytics, không có endpoint báo lỗi, không có telemetry, không có quảng cáo, không có fingerprinting.
+
+Repository chạy hoàn toàn trên:
+
+- **GitHub** (host mã nguồn, Actions, raw file CDN, Pages cho Webapp).
+- **Thiết bị của Bạn** (Webapp trong trình duyệt, hoặc Desktop App trong webview Tauri 2).
+- **itch.io** (trang game, được fetch theo yêu cầu bởi scraper hoặc tính năng preview của Desktop App).
+
+Người duy trì không có hạ tầng nào có thể thu thập dữ liệu của Bạn ngay cả khi muốn.
+
+## 3. GitHub
+
+Repository này, deployment Webapp (GitHub Pages) và artifact phát hành Desktop App được host trên GitHub. GitHub có thể log dữ liệu HTTP request tiêu chuẩn (địa chỉ IP, user agent, referrer) theo chính sách của họ. Người duy trì không có quyền truy cập các log đó ngoài insight cấp repository của GitHub (số clone / view tổng hợp).
+
+Chính sách Bảo mật của GitHub: <https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement>
+
+Khi Bạn đóng góp (mở issue, comment, fork, gửi PR), Bạn xuất bản thông tin đó trên GitHub dưới tài khoản của mình. Người duy trì chỉ thấy phần GitHub công khai.
+
+## 4. itch.io
+
+Tất cả link game trong Catalog trỏ trực tiếp tới trang itch.io. Click vào link sẽ đưa Bạn tới itch.io; những gì xảy ra ở đó được điều chỉnh bởi điều khoản và chính sách của itch.io:
+
+- Privacy Policy của itch.io: <https://itch.io/docs/legal/privacy-policy>
+- Terms of Service của itch.io: <https://itch.io/docs/legal/terms>
+
+GitHub Action `update.yml` của Repository cũng thực hiện request server-to-server tới itch.io để scrape metadata trang; những request đó đến từ dải IP của GitHub, không phải từ thiết bị của Bạn.
+
+## 5. Webapp lưu gì trong trình duyệt của Bạn
+
+Webapp lưu các mục sau cục bộ và **không bao giờ** gửi chúng tới bất kỳ server nào do Người duy trì kiểm soát.
+
+| Lưu trữ | Khóa | Nội dung | Khi nào ghi |
+|---|---|---|---|
+| `localStorage` | `webapp.pat.encrypted` | PAT GitHub của Bạn, mã hóa AES-GCM 256-bit. Khóa mã hóa được dẫn xuất từ passphrase qua PBKDF2-SHA256 (100.000 vòng) với salt ngẫu nhiên cho mỗi token. PAT plaintext **không bao giờ** được lưu xuống đĩa. | Khi Bạn bật quyền ghi trong Settings. |
+| `localStorage` | `webapp.theme` | Một trong `'light'`, `'dark'`, `'system'`. | Khi Bạn chuyển theme. |
+| `localStorage` | `webapp.prefs` | Tùy chỉnh UI (sidebar collapsed, độ rộng cột bảng). | Khi Bạn thay đổi tùy chỉnh UI. |
+| `IndexedDB` (qua `idb-keyval`) | Khóa cache TanStack Query | Bản sao cache của catalog JSON công khai để tải nhanh và đọc offline có giới hạn. | Tự động, sau lần fetch đầu tiên. |
+
+Bạn có thể xóa toàn bộ những gì ở trên bất kỳ lúc nào bằng cách:
+
+- Click **Settings → Remove saved PAT** (chỉ xóa entry PAT).
+- Dùng "Clear site data" / "Clear cookies and storage" của trình duyệt cho `poli0981.github.io` (xóa hết).
+- Gỡ Desktop App và xóa thư mục profile WebView2 / WebKit (chỉ Desktop; vị trí khác nhau theo OS).
+
+## 6. Xử lý PAT — chi tiết
+
+Tính năng ghi tùy chọn của Webapp (sửa annotation, dispatch workflow scraper, bulk delete) yêu cầu PAT fine-grained GitHub. Vòng đời PAT hoàn toàn ở phía client:
+
+1. **Tạo** — Bạn tạo PAT fine-grained trên github.com, giới hạn về `poli0981/free-games-itchio-list`, với `Contents: Read & write` và `Actions: Read & write`. Người duy trì không bao giờ thấy bước này.
+2. **Mã hóa** — Bạn dán PAT vào Settings + một passphrase. Webapp dẫn xuất khóa AES-GCM từ passphrase qua PBKDF2-SHA256 (100k vòng, salt ngẫu nhiên 16-byte). PAT được mã hóa; ciphertext + salt + IV được lưu vào `localStorage` ở khóa `webapp.pat.encrypted`. PAT plaintext và passphrase không bao giờ được ghi vào bất kỳ storage nào.
+3. **Mở khóa** — Ở session sau, Bạn nhập passphrase. Webapp dẫn xuất lại khóa và giải mã PAT vào store Zustand trong bộ nhớ. PAT đã giải mã chỉ tồn tại trong bộ nhớ JavaScript.
+4. **Sử dụng** — Lệnh gọi Octokit tới `api.github.com` bao gồm PAT dưới dạng `Authorization: Bearer <pat>` qua HTTPS. PAT chỉ được gửi tới `api.github.com` và không bao giờ tới host khác.
+5. **Khóa** — Click Lock (hoặc đóng tab) loại bỏ PAT trong bộ nhớ. Blob mã hóa vẫn còn trong `localStorage` cho lần mở khóa tiếp theo.
+6. **Xóa** — Click Remove saved PAT xóa entry `webapp.pat.encrypted` khỏi `localStorage`.
+
+Nếu Bạn nghi ngờ PAT bị lộ:
+
+- Khóa hoặc xóa nó ngay lập tức.
+- Thu hồi nó trên github.com (Settings → Developer settings → Personal access tokens → Fine-grained tokens).
+- Tạo PAT mới với passphrase mới.
+
+Xem thêm: [SECURITY.md](SECURITY.md).
+
+## 7. Network request
+
+Khi chạy, Webapp và Desktop App thực hiện request tới các endpoint sau — và chỉ những endpoint này:
+
+| Endpoint | Mục đích | Auth |
+|---|---|---|
+| `raw.githubusercontent.com/poli0981/free-games-itchio-list/main/data_game/*.json` | Đọc dữ liệu catalog công khai. | Không. |
+| `api.github.com/repos/poli0981/free-games-itchio-list/...` | Thao tác ghi: sửa, xóa, dispatch workflow, list run. | PAT (chỉ khi đã mở khóa). |
+| `*.itch.io/*`, `img.itch.zone/*` | (Chỉ Desktop App) Fetch itch.io trực tiếp cho preview game trong app, vượt CORS trình duyệt. | Không. |
+
+Không có CDN bên thứ ba, không endpoint analytics, không telemetry collector, không font CDN. Tailwind, Radix, lucide-react, v.v. đều được bundle ở build time.
+
+## 8. Cookie
+
+Webapp và Desktop App **không đặt bất kỳ cookie nào.** GitHub Pages có thể phát hành cookie như một phần của hành vi CDN; những cookie đó là của GitHub, không phải của Người duy trì.
+
+## 9. Quyền riêng tư của trẻ em
+
+Repository lập chỉ mục các game host trên itch.io, bao gồm cả nội dung người lớn. Cờ `nsfw` là best-effort (xem [DISCLAIMER §2](DISCLAIMER.md#2-không-bảo-đảm-về-các-game)). Webapp không gating truy cập theo tuổi. Nếu Bạn dưới tuổi thành niên ở khu vực của mình, vui lòng sử dụng Repository dưới sự giám sát của cha mẹ hoặc người giám hộ và tôn trọng age-gating của itch.io ở những nơi áp dụng.
+
+Người duy trì không cố ý thu thập dữ liệu cá nhân từ trẻ em. (Người duy trì không thu thập dữ liệu cá nhân từ bất kỳ ai — xem §2.)
+
+## 10. Quyền của Bạn
+
+Vì Người duy trì không nắm dữ liệu cá nhân nào, các yêu cầu theo GDPR, CCPA, Nghị định 13/2023/NĐ-CP của Việt Nam, hoặc các chế định tương tự nhằm vào Người duy trì sẽ không có gì để thực hiện. Đối với dữ liệu trên thiết bị của Bạn:
+
+- **Quyền truy cập**: mở DevTools trình duyệt → Application → Storage → Local Storage / IndexedDB.
+- **Quyền xóa**: clear site data như mô tả ở §5.
+- **Quyền chuyển đổi**: export `localStorage` qua DevTools (là JSON thuần; PAT đã mã hóa).
+
+Đối với dữ liệu mà GitHub hoặc itch.io nắm về tương tác của Bạn với nền tảng của họ, hãy liên hệ trực tiếp các nhà cung cấp đó qua đầu mối liên hệ về quyền riêng tư trong chính sách của họ.
+
+## 11. Dịch vụ bên thứ ba
+
+| Dịch vụ | Dùng cho | Chính sách |
+|---|---|---|
+| GitHub | Repo, CI, Pages, Releases, API | <https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement> |
+| itch.io | Trang game, nguồn scrape | <https://itch.io/docs/legal/privacy-policy> |
+
+Webapp **không** tích hợp bất kỳ nhà cung cấp analytics, mạng quảng cáo, dịch vụ báo lỗi (không Sentry, không Datadog), SDK mạng xã hội hay font CDN nào.
+
+## 12. Thay đổi Chính sách này
+
+Người duy trì có thể cập nhật Chính sách này. Ngày `Cập nhật lần cuối` ở đầu phản ánh thay đổi mới nhất. Các thay đổi trọng yếu sẽ được ghi thêm trong [CHANGELOG.md](../../../CHANGELOG.md). Việc tiếp tục sử dụng sau khi thay đổi đồng nghĩa với chấp nhận.
+
+## 13. Liên hệ
+
+Cho câu hỏi về Chính sách này:
+
+- Mở issue `[General]` hoặc `[Feedback]`.
+- DM qua bất kỳ kênh nào liệt kê trên [trang About](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+
+## 14. Lời cuối
+
+Không tracking, không analytics, không telemetry, không spying. Người duy trì quá lười và quá thất nghiệp để xây pipeline dữ liệu kể cả khi muốn. Cứ duyệt thoải mái.
+
+Built with boredom and zero data harvesting. 🚀

--- a/docs/i18n/vi/SECURITY.md
+++ b/docs/i18n/vi/SECURITY.md
@@ -1,0 +1,61 @@
+# Chính sách bảo mật
+
+Cập nhật lần cuối: 2026-05-05
+
+> **Lưu ý**: Bản dịch tiếng Việt mang tính tham khảo. Bản tiếng Anh tại [`SECURITY.md`](../../../SECURITY.md) là bản chính thức.
+
+Đây chủ yếu là một repo sở thích — danh sách được duy trì các game itch.io miễn phí, kèm script Python scrape trên GitHub Actions, cộng với webapp React/TypeScript (và Tauri desktop wrapper) để duyệt và sửa catalog. Vẫn không backend, không database, không telemetry. Thứ duy nhất liên quan tới bảo mật là Personal Access Token GitHub mà webapp có thể giữ cho thao tác ghi — xem bên dưới.
+
+## Phiên bản được hỗ trợ
+
+Mọi thứ ở đây chỉ là "commit mới nhất". Tôi thất nghiệp với quá nhiều thời gian, nên fix (nếu có) đến khi nào tôi cảm thấy thích — hoặc khi nào AI buddy nhắc.
+
+## Báo cáo lỗ hổng
+
+Tìm thấy thứ gì đáng sợ? Như script có thể spam itch.io theo lý thuyết hoặc lộ... gì đó? Bạn là huyền thoại.
+
+Vui lòng **đừng** mở issue công khai. Thay vào đó:
+
+- Mở **issue riêng tư** trên GitHub (nếu repo cho phép — tôi introvert, có thể không có email công khai).
+- Hoặc mở issue thường và prefix "[Security]" — tôi sẽ chuyển nó thành riêng tư nếu cần.
+- Mô tả vấn đề rõ ràng (các bước reproduce, tác động tiềm tàng).
+- Tôi sẽ review (với hỗ trợ AI, vì kiến thức bảo mật của tôi ở mức "easy mode").
+
+Mong đợi:
+
+- Tôi sẽ acknowledge trong vài ngày (lịch thất nghiệp, không phải 24/7).
+- Nếu hợp lệ (cái "nếu" lớn :v), tôi sẽ fix và credit bạn trong changelog/acknowledgements.
+- Nếu không hợp lệ — vẫn cảm ơn vì quan tâm tới code tầm thường của tôi.
+
+"Lỗ hổng" thường gặp bạn có thể tìm thấy:
+
+- Scraping vỡ nếu itch.io đổi HTML (không phải bảo mật, chỉ là cuộc đời).
+- Rate limiting? Tôi đã `sleep(2)` — hãy tử tế với server.
+- Dependencies? requests + bs4 ổn, nhưng cập nhật nếu cần.
+- Webapp deps (npm/Rust)? Dependabot/security alert trên repo lo việc đó — bump landing qua PR.
+
+## Xử lý PAT của Webapp (đọc nếu bạn dùng webapp có khả năng ghi)
+
+Các flow chỉ đọc (Dashboard, Games table, Charts, Deleted) **không** cần auth và dùng public CDN tại `raw.githubusercontent.com`. Các flow ghi (sửa annotation, bulk edit/delete, dispatch workflow scraper) cần GitHub Personal Access Token, mà webapp lưu như sau:
+
+- **Dùng PAT fine-grained** giới hạn về **chỉ** `poli0981/free-games-itchio-list` với scope tối thiểu bạn cần:
+  - `contents: write` — bắt buộc cho sửa / xóa / queue URL.
+  - `actions: write` — bắt buộc cho nút dispatch trang Add / Workflows.
+  - `metadata: read` ngầm định.
+- **Tại thiết bị** PAT được mã hóa AES-GCM 256-bit; khóa được dẫn xuất từ passphrase của bạn qua PBKDF2-SHA256 (100k vòng) với salt mới cho mỗi token. Blob mã hóa nằm trong `localStorage` ở `webapp.pat.encrypted`.
+- **Trong bộ nhớ** PAT đã giải mã chỉ tồn tại trong store Zustand của React app giữa lúc unlock và Lock tường minh (hoặc đóng tab).
+- **Khóa hoặc xóa bất kỳ lúc nào** từ Settings. Xóa cũng wipe entry localStorage.
+- **Đừng dán classic PAT** với scope full repo trừ khi bạn thực sự muốn. Token fine-grained giới hạn tới một repo và một bộ thao tác.
+- **Đừng share `localStorage`** giữa các user (ví dụ: máy kiosk dùng chung). Mã hóa bảo vệ PAT khỏi người đọc filesystem casual, không khỏi ai biết passphrase.
+
+Nếu bạn tìm cách bypass mã hóa, exfiltrate PAT từ bộ nhớ qua khe hở CSP, hoặc lừa webapp gửi ghi vào sai repo — vui lòng báo cáo riêng tư như trên.
+
+## Báo cáo lỗ hổng dependency Web/desktop
+
+Cho lỗ hổng crate Tauri/Rust hoặc CVE npm package ảnh hưởng webapp, mở issue `[Security]` thường là OK; nếu nó actively exploitable trên site Pages đã deploy, vui lòng prefix `[CRITICAL]` để tôi có thể yank deploy đến khi fix xong.
+
+Không có bounty (tài khoản < $50), nhưng cảm ơn vĩnh viễn và shoutout.
+
+Repo này MIT, rủi ro thấp. Hãy an toàn — đặc biệt khi tải các game miễn phí ngẫu nhiên.
+
+Cảm ơn vì đã báo cáo có trách nhiệm. Bạn đã giỏi bảo mật hơn tôi rồi. 🚀

--- a/docs/i18n/vi/ToS.md
+++ b/docs/i18n/vi/ToS.md
@@ -1,0 +1,130 @@
+# Điều khoản sử dụng (Terms of Use)
+
+Cập nhật lần cuối: 2026-05-05
+
+> **Lưu ý**: Đây là bản dịch tiếng Việt mang tính tham khảo cho cộng đồng. **Bản tiếng Anh tại [`docs/ToS.md`](../../ToS.md) là bản chính thức** và sẽ được dùng để giải thích trong trường hợp có khác biệt giữa hai phiên bản.
+
+Các Điều khoản sử dụng này ("Điều khoản") điều chỉnh việc Bạn sử dụng Repository, Webapp và Desktop App. Văn bản dùng ngôn ngữ phổ thông kèm chút humor có chủ đích — nhưng vẫn áp dụng được.
+
+> **Tóm tắt**: Đừng phá đồ, đừng spam, đừng thêm malware, đừng lạm dụng GitHub API hay itch.io. Dùng tính năng PAT của webapp một cách có trách nhiệm. Người duy trì có thể gỡ bất cứ thứ gì vì bất kỳ lý do nào.
+
+## 1. Định nghĩa
+
+Các thuật ngữ được định nghĩa trong [EULA §1](EULA.md#1-định-nghĩa) cũng áp dụng tại đây: "Repository", "Webapp", "Desktop App", "Catalog", "Người duy trì", "Bạn".
+
+## 2. Chấp nhận
+
+Bằng việc xem, clone, fork, star, đóng góp, mở issue, deploy, chạy, hoặc tương tác với Repository, Webapp hoặc Desktop App theo cách khác, Bạn đồng ý với các Điều khoản này. Nếu không đồng ý, đừng sử dụng.
+
+## 3. Sử dụng được phép
+
+Bạn được hoan nghênh:
+
+- Duyệt Catalog, trên GitHub hoặc qua Webapp / Desktop App.
+- Click sang trang itch.io và tải game (theo điều khoản của itch.io và của từng nhà phát triển).
+- Gửi URL game mới qua issue template **[Add Games]**.
+- Gửi yêu cầu gỡ qua **[Remove Games]**.
+- Báo bug, đề xuất tính năng, gửi feedback qua các template tương ứng.
+- Mở Pull Request với cải tiến code, dữ liệu hoặc tài liệu.
+- Tự host Webapp hoặc build Desktop App cho mục đích cá nhân, học tập, hoặc thương mại theo Giấy phép MIT.
+
+## 4. Nghĩa vụ của người đóng góp
+
+Nếu Bạn đóng góp cho Repository (issue, PR, sửa qua Webapp), Bạn cam đoan rằng:
+
+- Nội dung Bạn gửi (code, văn bản, URL game) hoặc là tác phẩm của chính Bạn, hoặc đã được ghi nguồn và cấp phép phù hợp để đưa vào.
+- URL game Bạn gửi trỏ đến game **thực sự miễn phí** trên itch.io. Bản demo của game trả phí, "name your own price (mức tối thiểu > 0)" và game được miễn phí có thời hạn không tính.
+- Nội dung gửi không chứa malware, không phishing, không doxxing, không vi phạm bản quyền, và không có gì làm xấu mặt mẹ của Người duy trì.
+- Bạn cấp cho Người duy trì quyền sáp nhập đóng góp của Bạn vào Repository theo Giấy phép MIT.
+
+## 5. Hành vi bị cấm
+
+Bạn đồng ý **không**:
+
+### 5.1 Catalog & nội dung
+
+- Gửi game không miễn phí, là scam, phát tán malware, hoặc vi phạm điều khoản của itch.io.
+- Spam tracker issue với bài đăng kém chất lượng, trùng lặp, hoặc lạc đề.
+- Gửi yêu cầu gỡ cho game không thuộc sở hữu của Bạn (dùng template **Bug Report** hoặc **Feedback** thay vào đó).
+- Đăng thông tin cá nhân của Người duy trì hoặc bất kỳ người đóng góp nào.
+
+### 5.2 Webapp
+
+- Sử dụng tính năng PAT của Webapp với token cấp quyền truy cập tới repository mà Bạn không được phép ghi.
+- Cố tình trích xuất PAT của người dùng khác từ thiết bị dùng chung bằng cách khai thác quyền truy cập browser-storage (cũng vi phạm điều khoản của GitHub).
+- Tìm cách phá vỡ mã hóa AES-GCM được áp dụng cho PAT trong `localStorage` để truy cập trái phép.
+- Dùng Webapp như một relay để thực hiện các cuộc gọi GitHub API tự động ở quy mô lớn vào repository hoặc tổ chức mà Bạn không được phép tương tác.
+
+### 5.3 itch.io và scraping
+
+- Liên tục trigger workflow `update.yml` đối với các URL theo cách tạo tải bất hợp lý lên itch.io (Webapp đã rate-limit phía client; đừng script vòng qua nó).
+- Fork scraper, gỡ rate-limit (`scraper.py` đang nghỉ 2.5–5 giây giữa các request + 15–30 giây sau mỗi 20 request) và chạy ở tần suất cao. Điều khoản của itch.io điều chỉnh truy cập tự động; Người duy trì không chịu trách nhiệm cho các fork vi phạm.
+
+### 5.4 Desktop App
+
+- Đóng gói lại các installer đã ký và phân phối lại như thể chúng được sản xuất bởi nhà cung cấp khác.
+- Bỏ trang About hoặc thông tin attribution trước khi phân phối Desktop App công khai.
+
+### 5.5 Chung
+
+- Sử dụng Repository, Webapp, hoặc Desktop App cho bất kỳ mục đích trái pháp luật nào theo luật ở khu vực của Bạn hoặc của Người duy trì (Việt Nam).
+- Quấy rối, đe dọa hoặc giả danh người khác qua bất kỳ kênh nào liên quan tới dự án này (issue, PR, server Discord, mạng xã hội).
+
+## 6. Personal Access Token (PAT) — trách nhiệm của Bạn
+
+Tính năng ghi tùy chọn của Webapp yêu cầu PAT fine-grained của GitHub. **Bạn** chịu trách nhiệm duy nhất về:
+
+- Chọn phạm vi PAT không rộng hơn mức Bạn thực sự cần (thông thường `Contents: Read & write` + `Actions: Read & write`, giới hạn về một repository duy nhất).
+- Chọn passphrase mạnh cho mã hóa AES-GCM tại thiết bị.
+- Khóa PAT (Settings → Lock) khi rời khỏi thiết bị dùng chung.
+- Xóa PAT (Settings → Remove saved PAT) khi không còn cần.
+- Xoay vòng PAT nếu Bạn nghi ngờ bị lộ.
+
+Người duy trì không bao giờ thấy, truyền, hoặc lưu PAT của Bạn. Xem [Privacy Policy](PrivacyPolicy.md) và [Security Policy](SECURITY.md) để biết chi tiết về vòng đời PAT.
+
+## 7. Sở hữu trí tuệ
+
+- Code, cấu trúc dữ liệu, script, các bảng được tạo, mã nguồn webapp và tài liệu là © Người duy trì (poli0981 / SkullMute), được cấp phép theo [Giấy phép MIT](../../../LICENSE).
+- Game và metadata game (tên, mô tả, screenshot, tag) thuộc các nhà phát triển tương ứng và itch.io. Xem [DISCLAIMER §4](DISCLAIMER.md#4-nội-dung-của-bên-thứ-ba).
+- Các thư viện open-source bên thứ ba được điều chỉnh bởi giấy phép riêng; xem mục **Third-party software** trong [trang About](https://poli0981.github.io/free-games-itchio-list/app/#/about).
+
+## 8. Chấm dứt
+
+Người duy trì có thể, bất kỳ lúc nào và không cần báo trước:
+
+- Gỡ hoặc sửa đổi bất kỳ nội dung nào (entry game, tài liệu, code).
+- Từ chối, đóng, hoặc ẩn issue, PR, hoặc comment vi phạm các Điều khoản này.
+- Block người dùng vi phạm lặp lại các Điều khoản này.
+- Gỡ hoặc lưu trữ Repository, deploy Webapp, hoặc bản phát hành Desktop App.
+
+Các bản tagged release (`vX.Y.Z`) được dự định giữ lại nhưng không có SLA.
+
+## 9. Thay đổi các Điều khoản
+
+Người duy trì có thể cập nhật các Điều khoản này. Ngày `Cập nhật lần cuối` ở đầu phản ánh thay đổi mới nhất. Việc tiếp tục sử dụng sau khi thay đổi đồng nghĩa với chấp nhận. Các thay đổi trọng yếu sẽ được ghi thêm trong [CHANGELOG.md](../../../CHANGELOG.md).
+
+## 10. Luật áp dụng và tranh chấp
+
+Các Điều khoản này được điều chỉnh bởi pháp luật của **Cộng hòa Xã hội Chủ nghĩa Việt Nam**, không xét đến nguyên tắc xung đột pháp luật.
+
+Tranh chấp được giải quyết theo thứ tự sau:
+
+1. **Không chính thức trước**: mở issue `[Feedback]` hoặc `[General]`, hoặc DM qua bất kỳ kênh nào liệt kê trên [trang About](https://poli0981.github.io/free-games-itchio-list/app/#/about). Hầu hết bất đồng dừng ở đây.
+2. **Hòa giải**: nếu liên hệ không chính thức không thành, các bên có thể thử hòa giải theo thỏa thuận chung.
+3. **Tòa án**: nếu mọi cách đều thất bại, tòa án có thẩm quyền của Việt Nam có thẩm quyền độc quyền.
+
+## 11. Tính độc lập của các điều khoản
+
+Nếu bất kỳ điều khoản nào của Điều khoản này bị coi là vô hiệu hoặc không thể cưỡng chế, các điều khoản còn lại vẫn giữ đầy đủ hiệu lực.
+
+## 12. Không phải tư vấn pháp lý
+
+Các Điều khoản này là tài liệu cho dự án sở thích, được soạn bởi một người không phải luật sư, có hỗ trợ AI. Không thay thế tư vấn pháp lý chuyên nghiệp.
+
+## 13. Lời cuối
+
+Đây vẫn là một danh sách game miễn phí + một webapp + một desktop app, xây dựng bởi một dev mệt mỏi và hai LLM. Hãy "be cool", đừng phá đồ, vui vẻ, và mọi người đều hòa thuận.
+
+Câu hỏi? Mở issue. Hoặc DM qua bất kỳ kênh nào trên trang About. Người duy trì sẽ cố gắng không ghost.
+
+Built with boredom, zero budget, and two AI buddies who actually read the EULA. 🚀

--- a/webapp/src-tauri/tauri.conf.json
+++ b/webapp/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
         "minWidth": 900,
         "minHeight": 600,
         "resizable": true,
+        "maximizable": false,
         "fullscreen": false
       }
     ],

--- a/webapp/src/components/data-table/data-table.tsx
+++ b/webapp/src/components/data-table/data-table.tsx
@@ -113,7 +113,7 @@ export function DataTable<TData>({
   return (
     <div className="space-y-2">
       <div className="rounded-md border bg-card">
-      <div ref={parentRef} className="relative max-h-[calc(100vh-280px)] overflow-auto">
+      <div ref={parentRef} className="scrollbar-hide relative max-h-[calc(100vh-280px)] overflow-auto">
         <table className="w-full text-sm">
           <thead className="sticky top-0 z-10 bg-card shadow-[inset_0_-1px_0_hsl(var(--border))]">
             {headerGroups.map((hg) => (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -63,3 +63,13 @@
     margin: 0;
   }
 }
+
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -89,6 +89,39 @@ export const SOCIAL_GROUP_LABELS: Record<SocialGroup, string> = {
   gaming: 'Gaming',
 }
 
+const REPO_BLOB = 'https://github.com/poli0981/free-games-itchio-list/blob/main'
+
+export type LegalGroup = 'policy' | 'meta'
+
+export interface LegalLink {
+  name: string
+  description: string
+  url: string
+  group: LegalGroup
+}
+
+export const LEGAL_LINKS: LegalLink[] = [
+  // Policy
+  { name: 'Disclaimer',      description: 'No warranty, no liability, "as-is" basis.',                              url: `${REPO_BLOB}/docs/DISCLAIMER.md`,     group: 'policy' },
+  { name: 'EULA',            description: 'MIT-licensed; what the license does and does not cover.',                url: `${REPO_BLOB}/docs/EULA.md`,           group: 'policy' },
+  { name: 'Terms of Use',    description: 'Permitted uses, prohibited activities, contributor obligations, PAT.',   url: `${REPO_BLOB}/docs/ToS.md`,            group: 'policy' },
+  { name: 'Privacy Policy',  description: 'Zero server-side data collection. Local-only browser storage detailed.', url: `${REPO_BLOB}/docs/PrivacyPolicy.md`,  group: 'policy' },
+  { name: 'Code of Conduct', description: 'Be cool. The full version is on GitHub.',                                url: `${REPO_BLOB}/CODE_OF_CONDUCT.md`,     group: 'policy' },
+  { name: 'Security Policy', description: 'Reporting vulnerabilities + PAT handling overview.',                     url: `${REPO_BLOB}/SECURITY.md`,            group: 'policy' },
+
+  // Meta
+  { name: 'License (MIT)',   description: 'The canonical license text.',                                            url: `${REPO_BLOB}/LICENSE`,                group: 'meta' },
+  { name: 'Changelog',       description: 'What changed when.',                                                     url: `${REPO_BLOB}/CHANGELOG.md`,           group: 'meta' },
+]
+
+export const LEGAL_GROUP_LABELS: Record<LegalGroup, string> = {
+  policy: 'Policies',
+  meta: 'Meta',
+}
+
+export const LEGAL_VI_INDEX_URL =
+  'https://github.com/poli0981/free-games-itchio-list/tree/main/docs/i18n/vi'
+
 export const THIRD_PARTY: ThirdParty[] = [
   // Core
   { name: 'React', version: '19.2', license: 'MIT', url: 'https://react.dev', category: 'core' },

--- a/webapp/src/routes/about.tsx
+++ b/webapp/src/routes/about.tsx
@@ -9,6 +9,7 @@ import {
   Hash,
   Heart,
   MessagesSquare,
+  ScrollText,
   Video,
   type LucideIcon,
 } from 'lucide-react'
@@ -22,10 +23,14 @@ import {
   APP,
   DEV,
   ERROR_TEMPLATE_URL,
+  LEGAL_GROUP_LABELS,
+  LEGAL_LINKS,
+  LEGAL_VI_INDEX_URL,
   SOCIAL_GROUP_LABELS,
   SOCIAL_LINKS,
   THIRD_PARTY,
   UPSTREAM_DATA,
+  type LegalGroup,
   type SocialGroup,
   type SocialLink,
   type ThirdParty,
@@ -52,6 +57,7 @@ const SOCIAL_ICON: Record<string, LucideIcon> = {
 }
 
 const SOCIAL_GROUP_ORDER: SocialGroup[] = ['social', 'community', 'support', 'gaming']
+const LEGAL_GROUP_ORDER: LegalGroup[] = ['policy', 'meta']
 
 function ThirdPartySection({ category }: { category: ThirdParty['category'] }) {
   const items = THIRD_PARTY.filter((t) => t.category === category)
@@ -230,6 +236,55 @@ export default function About() {
               <SocialGroupSection group={group} />
             </div>
           ))}
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ScrollText className="h-4 w-4" />
+            Legal &amp; policies
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">
+            All policies are MD files in the repo — short, plain-language, slight humor, full
+            on-the-record terms. Updated 2026-05-05.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-5 text-sm">
+          {LEGAL_GROUP_ORDER.map((group, i) => {
+            const items = LEGAL_LINKS.filter((l) => l.group === group)
+            if (items.length === 0) return null
+            return (
+              <div key={group} className="space-y-2">
+                {i > 0 && <Separator />}
+                <h3 className="text-sm font-semibold text-muted-foreground">
+                  {LEGAL_GROUP_LABELS[group]}
+                </h3>
+                <ul className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                  {items.map((link) => (
+                    <li key={link.name} className="rounded-md border p-2">
+                      <ExtLink
+                        href={link.url}
+                        className="inline-flex items-center gap-1 font-medium hover:underline"
+                      >
+                        {link.name}
+                        <ExternalLinkIcon className="h-3 w-3 opacity-50" />
+                      </ExtLink>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{link.description}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          })}
+          <p className="pt-1 text-xs text-muted-foreground">
+            Tiếng Việt:{' '}
+            <ExtLink href={LEGAL_VI_INDEX_URL} className="font-medium hover:underline">
+              docs/i18n/vi/
+            </ExtLink>{' '}
+            — Vietnamese translations of the policies above (community-readable, English remains
+            the controlling version for legal interpretation).
+          </p>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

Largest doc + policy pass since v3.0.0. Tightens the four legal docs while keeping the project's voice, ships full Vietnamese translations under `docs/i18n/vi/`, surfaces every policy from the About page, and lands two small optional UI items (locked desktop maximize + hidden table scrollbar).

## Changes

### Legal docs (rewritten — tighter, slight more formal, humor preserved)
- **`docs/DISCLAIMER.md`** — TL;DR, "AS IS" basis, no-warranty per-game enumeration (quality / safety / NSFW / metadata / free-to-play status), no-liability, third-party content, removal-request path, governing law (Vietnam), severability, "not legal advice".
- **`docs/EULA.md`** — definitions, MIT grant, scope (what the license does NOT cover: games, third-party libs, itch.io marks, screenshots), restrictions, termination, governing law, severability.
- **`docs/ToS.md`** — definitions, permitted uses, contributor obligations, prohibited activities (catalog & content / webapp / itch.io scraping / desktop / general), PAT user responsibility, IP, termination, dispute resolution (informal → mediation → court), governing law, severability.
- **`docs/PrivacyPolicy.md`** — fully rewritten (also fixes encoding glyphs in the old footer). Per-storage table for everything the webapp persists, full PAT lifecycle (create → encrypt → unlock → use → lock → remove), explicit network-endpoint table, no-cookies note, GDPR/CCPA/PDPD-style "your rights" section, third-party services table.

### Vietnamese i18n
- **`README.vi.md`** at repo root (GitHub language-detection convention) with badge link from main `README.md`.
- **`docs/i18n/vi/`** — full translations of: `DISCLAIMER.md`, `EULA.md`, `ToS.md`, `PrivacyPolicy.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CONTRIBUTING.md`. Each VI file states the English version is the controlling text for legal interpretation.

### About page
- New **"Legal & policies"** Card with `LEGAL_LINKS` grouped into Policies (Disclaimer / EULA / ToS / Privacy / CoC / Security) and Meta (LICENSE / Changelog), each with description, plus a tail pointer to `docs/i18n/vi/`.
- `webapp/src/lib/about.ts`: `LegalLink` interface + `LEGAL_LINKS` array + `LEGAL_VI_INDEX_URL`. Same structured pattern as existing `THIRD_PARTY` / `SOCIAL_LINKS`.

### Optional UI
- **Tauri** (`webapp/src-tauri/tauri.conf.json`): `"maximizable": false` — the OS maximize button (and double-click on title bar / Win+Up) is disabled. Window remains resizable within `minWidth: 900` / `minHeight: 600`.
- **DataTable** (`webapp/src/components/data-table/data-table.tsx` + `webapp/src/index.css`): new `.scrollbar-hide` Tailwind utility (Firefox `scrollbar-width: none` + WebKit `::-webkit-scrollbar { display: none }` + IE/Edge `-ms-overflow-style: none`) applied to the scroll container.

### Bookkeeping
- `README.md` version badge → `3.1.4`, new Vietnamese language badge, short pointer block to `README.vi.md` and `docs/i18n/vi/`.
- `CHANGELOG.md` v3.1.4 entry.

## Test plan

- [x] `npm run build` — TS clean, About chunk 11.99 → 14.61 kB (gzip 3.63 → 4.39 kB) due to new Card + LEGAL_LINKS data.
- [x] `npm run lint` — 14 errors + 5 warnings, all pre-existing in shadcn primitives + `routes/games.tsx` + `data-table.tsx` (TanStack Table react-compiler skip — present before this PR).
- [ ] Post-merge: `deploy_webapp.yml` rebuilds GitHub Pages → About page shows new Legal Card, table shows no scrollbar chrome.
- [ ] Post-merge: `release_desktop.yml` triggers on `v3.1.4` tag → installers built. Verify on a desktop install: maximize button is greyed/absent, double-click on title bar does nothing, window can still be resized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)