### PR TITLE
release(v3.2.1): single-instance enforcement on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented here.
 
+## [3.2.1] - 2026-05-11 (Hotfix: single-instance enforcement on desktop)
+
+### Fixed
+
+- **Desktop app spawned a new process on every launch.** Each double-click of the installed app added another `free-games-itchio-webapp.exe` (Windows) / equivalent on macOS+Linux to the task list instead of focusing the existing window. Added [`tauri-plugin-single-instance`](https://tauri.app/plugin/single-instance/) v2 in [`webapp/src-tauri/src/lib.rs`](webapp/src-tauri/src/lib.rs) — second launch now unminimizes + focuses the running window and exits its own process before creating a duplicate. Plugin registered first in the builder chain per Tauri 2 docs so duplicate processes die before initializing HTTP/opener plugins. Gated by `#[cfg(desktop)]` + matching `cfg(not(android, ios))` in [`Cargo.toml`](webapp/src-tauri/Cargo.toml). Desktop binary boundary change → bumped [`Cargo.toml`](webapp/src-tauri/Cargo.toml) and [`tauri.conf.json`](webapp/src-tauri/tauri.conf.json) from `0.1.0` to `0.1.1` (first time these have moved since v3.0.0).
+
+### Changed
+
+- **README + README.vi badges** bumped to `3.2.1`.
+- **About page** lists `tauri-plugin-single-instance` v2 under Desktop dependencies.
+
+---
+
 ## [3.2.0] - 2026-05-10 (CI cleanup + mobile + SEO + Telegram bot path + auto-discussion)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.2.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.2.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,6 +1,6 @@
 # Danh sách Game Itch.io Miễn Phí
 
-[![Version](https://img.shields.io/badge/version-3.2.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.2.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md)
 

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "free-games-itchio-webapp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Itch.io free games catalog browser & editor"
 authors = ["poli0981"]
 license = "MIT"
@@ -21,6 +21,9 @@ tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-single-instance = "2"
 
 [profile.release]
 panic = "abort"

--- a/webapp/src-tauri/src/lib.rs
+++ b/webapp/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use tauri::Manager;
 
 #[derive(Serialize)]
 struct RuntimeInfo {
@@ -16,7 +17,20 @@ fn runtime_info() -> RuntimeInfo {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.unminimize();
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }));
+    }
+
+    builder
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![runtime_info])

--- a/webapp/src-tauri/tauri.conf.json
+++ b/webapp/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Itch.io Free Games DB",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.poli0981.free-games-itchio-webapp",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -8,7 +8,7 @@ export interface ThirdParty {
 
 export const APP = {
   name: 'Itch.io Free Games DB',
-  version: '3.2.0',
+  version: '3.2.1',
   repo: 'https://github.com/poli0981/free-games-itchio-list',
   license: 'MIT',
   buildDate: typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : 'dev',
@@ -164,6 +164,7 @@ export const THIRD_PARTY: ThirdParty[] = [
   { name: '@tauri-apps/api', version: '2.11', license: 'Apache-2.0 OR MIT', url: 'https://tauri.app', category: 'desktop' },
   { name: 'tauri-plugin-http', version: '2', license: 'Apache-2.0 OR MIT', url: 'https://tauri.app', category: 'desktop' },
   { name: 'tauri-plugin-opener', version: '2', license: 'Apache-2.0 OR MIT', url: 'https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/opener', category: 'desktop' },
+  { name: 'tauri-plugin-single-instance', version: '2', license: 'Apache-2.0 OR MIT', url: 'https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/single-instance', category: 'desktop' },
 ]
 
 export const UPSTREAM_DATA = {


### PR DESCRIPTION
## Summary

Hotfix for the desktop app: every launch spawned a new process instead of focusing the existing window. Added `tauri-plugin-single-instance` v2 in the Tauri builder chain so duplicate launches exit immediately and bring the existing window forward.

## What changed

- **Rust binary** ([webapp/src-tauri/src/lib.rs](webapp/src-tauri/src/lib.rs)): single-instance plugin registered first under `#[cfg(desktop)]`. Callback unminimizes + shows + focuses the `main` window when a duplicate launch is attempted.
- **Cargo.toml**: target-gated dependency `tauri-plugin-single-instance = "2"` for `cfg(not(any(target_os = "android", target_os = "ios")))`. Binary version bumped `0.1.0 → 0.1.1` (first desktop boundary change since v3.0.0).
- **tauri.conf.json**: version `0.1.0 → 0.1.1` (keeps installer filenames distinct from v3.2.0).
- **About page** + **README badges** + **CHANGELOG** bumped to `3.2.1`.

## Test plan

- [x] `cargo check` passed in 53.82s (`tauri-plugin-single-instance v2.4.2` resolved, no warnings).
- [x] Local `npm run tauri:dev` — duplicate launch focuses existing window, no second process in Task Manager. First launch still works.
- [ ] CI: `release_desktop.yml` will build Tauri installers for Win / macOS (aarch64 + x86_64) / Linux on `v3.2.1` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)