### PR TITLE
release(v3.3.0): mobile polish + Settings cards + in-browser GPG commit signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented here.
 
+## [3.3.0] - 2026-05-16 (Mobile polish + Settings + in-browser GPG commit signing)
+
+### Added
+
+- **In-browser GPG commit signing.** Every write the webapp makes (single-file edits, bulk edit/delete, queueing URLs) can now be GPG-signed client-side. New `webapp/src/lib/gpg/` module: [`canonicalize.ts`](webapp/src/lib/gpg/canonicalize.ts) builds the exact byte string Git would hash, [`sign.ts`](webapp/src/lib/gpg/sign.ts) lazy-imports `openpgp` and exposes `loadPrivateKey` / `signCommit` / `verifyDetached`, [`storage.ts`](webapp/src/lib/gpg/storage.ts) wraps localStorage helpers. Verified byte-for-byte against `git cat-file commit <sha>` so the signed canonical exactly matches what GitHub will recompute (no trailing-newline drift). Private keys are decrypted once at import and re-encrypted with the webapp passphrase (AES-GCM, same scheme as the PAT) — `openpgp` is loaded only when the Commit Signing card is opened or a commit is being signed (`vendor-openpgp` chunk, ~129 KB gz, lazy).
+- **Settings → Commit signing card.** New [`webapp/src/components/settings/gpg-card.tsx`](webapp/src/components/settings/gpg-card.tsx) — three states (not configured / locked / unlocked) with Import (paste armored or upload `.asc`), Unlock, Test sign (round-trip verify), Copy public key, Lock, Remove. Shows the imported key's UIDs as badges and flags a clear mismatch warning if the configured commit-author email isn't in the key's UID list (the most common cause of GitHub's "Someone may be trying to trick you" warning). After import, primary UID email auto-populates Commit author so commits Verify on the first try.
+- **Settings Phase A — Appearance / Session / Commit author / Notifications cards.** [`webapp/src/routes/settings.tsx`](webapp/src/routes/settings.tsx) gained four new cards backed by extended preferences in [`webapp/src/stores/prefs.ts`](webapp/src/stores/prefs.ts): theme picker (Light / Dark / System), layout density (Normal / Compact), sidebar collapse mirror, idle-timeout slider (5 / 15 / 30 / 60 / 120 min — replaces the hard-coded 30-min constant in [`auth.ts`](webapp/src/stores/auth.ts)), commit-author name/email override, toast enable + duration. Density applies via `html[data-density='compact']` rules in [`index.css`](webapp/src/index.css); toasts are gated through a new [`AppToaster`](webapp/src/components/app-toaster.tsx) wrapper that reads prefs.
+- **Mobile card view for the games table.** New [`webapp/src/lib/use-is-mobile.ts`](webapp/src/lib/use-is-mobile.ts) (`matchMedia('(max-width: 767px)')`) and [`webapp/src/components/data-table/mobile-card-list.tsx`](webapp/src/components/data-table/mobile-card-list.tsx). Below the `md` breakpoint, [`DataTable`](webapp/src/components/data-table/data-table.tsx) renders a stacked card list (thumbnail + name + dev + genre/status/NSFW/safe badges, tap-to-detail, selection checkbox) instead of the 9-column virtualized table that overflowed at 430 px. Pagination is shared between both views.
+- **Workflows route mobile fallback.** [`workflows.tsx`](webapp/src/routes/workflows.tsx) now dual-renders the action picker — a `<Select>` dropdown below `md`, the existing `TabsList` at `md` and above. Fixes the overflow from five `whitespace-nowrap` triggers in an `inline-flex` TabsList at 430 px viewport.
+
+### Changed
+
+- **All write paths route through the Git Data API.** [`webapp/src/lib/github/contents.ts`](webapp/src/lib/github/contents.ts) `putFile` (`PUT /repos/.../contents/{path}`) is gone — that endpoint authors commits as the PAT and never accepts a `signature` field. Replaced with `commitSingleFile` which delegates to [`atomicCommit`](webapp/src/lib/github/git-data.ts) so single-file edits (game annotations, `temp_link.json` queue) get the same signer plumbing as bulk operations. `atomicCommit` gained an optional `signer` parameter (defaulting to [`getSignerIfEnabled()`](webapp/src/lib/github/signer.ts)) that, when present, builds the canonical commit object, signs detached binary-mode via openpgp, and passes `author` / `committer` / `signature` to `git.createCommit`. Commit author identity falls back through prefs override → imported key's primary UID email → GitHub user.
+- **About page** lists `OpenPGP.js` 6.3 under Data dependencies; the [`webapp/vite.config.ts`](webapp/vite.config.ts) `manualChunks` rule emits a dedicated `vendor-openpgp` chunk so the cost is only paid when a user opens the signing card.
+- **README + README.vi badges** bumped to `3.3.0`.
+
+### Fixed
+
+- **Workflows `/workflows` tabs no longer overflow on mobile.** Pre-fix: five `whitespace-nowrap` triggers in an `inline-flex` TabsList blew past a 430 px viewport.
+- **DataTable no longer overflows on mobile.** Pre-fix: nine fixed-width columns minus three responsive-hidden ones still exceeded 430 px.
+
+---
+
 ## [3.2.1] - 2026-05-11 (Hotfix: single-instance enforcement on desktop)
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Path alias: `@/*` → `webapp/src/*`. Vite `define`s `__BUILD_DATE__` so About p
 
 ## Code-split layout
 
-`vite.config.ts` `manualChunks` splits node_modules into `vendor-react` / `vendor-query` / `vendor-ui` / `vendor-charts` (Recharts, ~380 KB) / `vendor-github` (Octokit, ~100 KB). Routes `/charts`, `/add`, `/workflows`, `/settings`, `/about`, `/games/:slug` are `React.lazy` so the initial bundle stays ~163 KB gzip.
+`vite.config.ts` `manualChunks` splits node_modules into `vendor-react` / `vendor-query` / `vendor-ui` / `vendor-charts` (Recharts, ~380 KB) / `vendor-github` (Octokit, ~100 KB) / `vendor-openpgp` (OpenPGP.js, ~387 KB — lazy, only touched when Settings → Commit Signing is opened or a commit is being signed). Routes `/charts`, `/add`, `/workflows`, `/settings`, `/about`, `/games/:slug` are `React.lazy` so the initial bundle stays ~163 KB gzip.
 
 ## Webapp structure
 
@@ -37,9 +37,11 @@ Path alias: `@/*` → `webapp/src/*`. Vite `define`s `__BUILD_DATE__` so About p
 - `src/components/data-table/*` — `DataTable` (TanStack Table + Virtual + pagination), `data-table-toolbar`, `data-table-pagination`, `faceted-filter`, `columns`. Row keys are URL-based (`getRowId: g => g.url`) so selection survives sort/filter/page changes.
 - `src/components/ui/*` — shadcn primitives (Button, Card, Input, Label, Badge, Skeleton, Separator, Tabs, Popover, Checkbox, Select, Switch, Textarea, Dialog).
 - `src/components/charts.tsx` — 9 Recharts charts grouped into 4 tabs.
-- `src/lib/github/` — `client.ts` (Octokit factory), `data-store.ts` (TS port of `scripts/data_store.py`), `contents.ts` (single-file PUT with sha conflict check), `git-data.ts` (atomic multi-file commit), `workflow.ts` (dispatch + poll).
+- `src/lib/github/` — `client.ts` (Octokit factory), `data-store.ts` (TS port of `scripts/data_store.py`), `contents.ts` (single-file commits — routed through Git Data API so they can be signed), `git-data.ts` (atomic multi-file commit; optional signer for GPG), `signer.ts` (builds a `CommitSigner` from gpg store + auth + prefs), `workflow.ts` (dispatch + poll).
+- `src/lib/gpg/` — `canonicalize.ts` (pure: builds the byte string Git would hash for a commit), `sign.ts` (lazy-imports `openpgp`, exports `loadPrivateKey` / `signCommit` / `verifyDetached`), `storage.ts` (encrypted-key + metadata in localStorage).
 - `src/lib/crypto.ts` — AES-GCM 256 + PBKDF2-SHA256 100k rounds. **Uint8Array generic must be `<ArrayBuffer>`** under TS 6, not `<ArrayBufferLike>` — Web Crypto rejects the latter.
-- `src/stores/` — Zustand stores: `auth` (in-memory PAT + GitHub user), `theme`, `prefs` (sidebar collapsed), `undo` (20-entry FIFO of reverse ops).
+- `src/lib/use-is-mobile.ts` — `useIsMobile()` hook based on `matchMedia('(max-width: 767px)')`. Use it for branches that need a distinct mobile layout (e.g. card view instead of a wide table).
+- `src/stores/` — Zustand stores: `auth` (in-memory PAT + GitHub user; idle timeout pulled from `prefs`), `theme`, `prefs` (sidebar collapsed + density + idle timeout + author override + notification settings), `gpg` (in-memory PrivateKey + fingerprint + uid + enabled), `undo` (20-entry FIFO of reverse ops).
 - `src/lib/about.ts` — keep the `THIRD_PARTY` array up to date when adding npm deps; About page reads it.
 
 ## Editable vs read-only fields
@@ -90,6 +92,10 @@ Fine-grained PAT scoped to **only this repo** with:
 8. **`/repos/.../contents` `content` is base64 with newlines**; strip them before decoding (`atob(data.content.replace(/\n/g, ''))`).
 9. **`createWorkflowDispatch` returns 204 with no run id.** To track the run, list runs filtered by `event=workflow_dispatch` and a dispatch timestamp from a few seconds before.
 10. **`docs/app/` is gitignored.** CI builds it. Don't commit build output.
+11. **PUT `/repos/.../contents/{path}` can never be "Verified".** GitHub authors that commit itself from the PAT; there is no `signature` field. All webapp writes must go through the Git Data API (blob → tree → commit → updateRef) to allow GPG signing. `contents.ts` `putFile` was removed for this reason — use `commitSingleFile` (wraps `atomicCommit`).
+12. **GPG signing must use binary mode in openpgp.js.** `openpgp.createMessage({ text })` normalizes line endings before hashing → signature won't verify against the LF-only Git commit object. Use `createMessage({ binary: TextEncoder.encode(canonical) })`.
+13. **Commit object canonical timestamp must match Octokit's `author.date` exactly.** GitHub re-derives `<unix_ts> <±HHMM>` from the ISO date and recomputes the SHA. Use a single `ts + tzOffsetMin` source for both, derive `author.date` via `isoFromTs(ts, tzOffsetMin)`.
+14. **TabsList primitive is `inline-flex` with `whitespace-nowrap` triggers.** Many tabs + narrow viewport → overflow. The fix in `/workflows` is dual-render: `<Select>` on mobile (`md:hidden`), TabsList on desktop (`hidden md:inline-flex`). Charts uses `flex-wrap` defensively but the labels are short enough to fit at 430px.
 
 ## Safe-edit rules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.2.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.3.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,6 +1,6 @@
 # Danh sách Game Itch.io Miễn Phí
 
-[![Version](https://img.shields.io/badge/version-3.2.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.3.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md)
 

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -17,7 +17,7 @@ The webapp + Tauri desktop build on a stack of open-source libraries — full ve
 
 - **Core**: React 19, TypeScript 6, Vite 8, React Router 7, Zustand 5, Zod 4
 - **UI**: Tailwind CSS 3, shadcn/ui (pattern), Radix UI primitives, lucide-react, sonner, class-variance-authority, tailwind-merge, clsx, Recharts
-- **Data**: TanStack Query / Table / Virtual, react-hook-form + `@hookform/resolvers`, `@octokit/rest`, `idb-keyval`
+- **Data**: TanStack Query / Table / Virtual, react-hook-form + `@hookform/resolvers`, `@octokit/rest`, `idb-keyval`, `openpgp` (lazy-loaded for in-browser commit signing)
 - **Desktop**: Tauri 2, `@tauri-apps/api`, `tauri-plugin-http`, `tauri-plugin-opener`
 
 When you add a new dep to `webapp/package.json`, also add it to the `THIRD_PARTY` array so the About page lists it. House rule documented in [CONTRIBUTING.md §8](../CONTRIBUTING.md#8-webapp-changes-react--ts).

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -32,6 +32,7 @@
         "clsx": "^2.1.1",
         "idb-keyval": "^6.2.2",
         "lucide-react": "^1.14.0",
+        "openpgp": "^6.3.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.75.0",
@@ -4751,6 +4752,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/openpgp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.0.tgz",
+      "integrity": "sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag==",
+      "license": "LGPL-3.0+",
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/optionator": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "idb-keyval": "^6.2.2",
     "lucide-react": "^1.14.0",
+    "openpgp": "^6.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.75.0",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, useLocation } from 'react-router-dom'
 import { Sidebar, MobileTopBar } from '@/components/sidebar'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useThemeEffect } from '@/hooks/useThemeEffect'
+import { useDensityEffect } from '@/hooks/useDensityEffect'
 import Dashboard from '@/routes/dashboard'
 import Games from '@/routes/games'
 import Deleted from '@/routes/deleted'
@@ -43,6 +44,7 @@ function ScrollToHash() {
 
 export default function App() {
   useThemeEffect()
+  useDensityEffect()
   return (
     <div className="flex h-[100dvh] overflow-hidden">
       <ScrollToHash />

--- a/webapp/src/components/app-toaster.tsx
+++ b/webapp/src/components/app-toaster.tsx
@@ -1,0 +1,9 @@
+import { Toaster } from 'sonner'
+import { usePrefs } from '@/stores/prefs'
+
+export function AppToaster() {
+  const enabled = usePrefs((s) => s.notificationsEnabled)
+  const duration = usePrefs((s) => s.notificationDurationMs)
+  if (!enabled) return null
+  return <Toaster richColors position="top-right" duration={duration} />
+}

--- a/webapp/src/components/data-table/data-table.tsx
+++ b/webapp/src/components/data-table/data-table.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useRef } from 'react'
+import { type ReactNode, useMemo, useRef } from 'react'
 import {
   type ColumnDef,
   type ColumnFiltersState,
   type PaginationState,
+  type Row,
   type RowSelectionState,
   type SortingState,
   flexRender,
@@ -15,6 +16,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { DataTablePagination } from './data-table-pagination'
 import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/lib/use-is-mobile'
 
 const ROW_HEIGHT = 56
 
@@ -46,6 +48,7 @@ interface DataTableProps<TData> {
   globalFilterFn: (row: TData, query: string) => boolean
   rowKey: (row: TData) => string
   getRowId?: (row: TData) => string
+  renderMobileList?: (rows: Row<TData>[]) => ReactNode
 }
 
 export function DataTable<TData>({
@@ -64,7 +67,9 @@ export function DataTable<TData>({
   globalFilterFn,
   rowKey,
   getRowId,
+  renderMobileList,
 }: DataTableProps<TData>) {
+  const isMobile = useIsMobile()
   const enablePagination = !!pagination && !!onPaginationChange
   const table = useReactTable({
     data,
@@ -121,6 +126,15 @@ export function DataTable<TData>({
   const virtualItems = virtualizer.getVirtualItems()
 
   const headerGroups = useMemo(() => table.getHeaderGroups(), [table])
+
+  if (isMobile && renderMobileList) {
+    return (
+      <div className="space-y-2">
+        {renderMobileList(rows)}
+        {enablePagination && <DataTablePagination table={table} />}
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-2">

--- a/webapp/src/components/data-table/mobile-card-list.tsx
+++ b/webapp/src/components/data-table/mobile-card-list.tsx
@@ -1,0 +1,106 @@
+import { Link } from 'react-router-dom'
+import type { Row } from '@tanstack/react-table'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import type { Game } from '@/types/game'
+import { slugify } from '@/lib/utils'
+
+interface MobileCardListProps {
+  rows: Row<Game>[]
+  selectable?: boolean
+}
+
+export function MobileCardList({ rows, selectable }: MobileCardListProps) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border bg-card p-6 text-center text-sm text-muted-foreground">
+        No results.
+      </div>
+    )
+  }
+
+  return (
+    <ul className="space-y-2">
+      {rows.map((row) => {
+        const g = row.original
+        const slug = slugify(g.url)
+        return (
+          <li key={g.url}>
+            <article className="flex gap-3 rounded-md border bg-card p-3 hover:bg-accent/40">
+              {selectable && (
+                <div className="flex shrink-0 items-start pt-1">
+                  <Checkbox
+                    checked={row.getIsSelected()}
+                    onCheckedChange={(v) => row.toggleSelected(!!v)}
+                    aria-label={`Select ${g.name}`}
+                  />
+                </div>
+              )}
+              <Link
+                to={`/games/${encodeURIComponent(slug)}`}
+                className="flex min-w-0 flex-1 gap-3"
+              >
+                {g.thumbnail ? (
+                  <img
+                    src={g.thumbnail}
+                    alt=""
+                    width={72}
+                    height={56}
+                    loading="lazy"
+                    decoding="async"
+                    className="h-14 w-[72px] shrink-0 rounded object-cover"
+                  />
+                ) : (
+                  <div
+                    aria-hidden="true"
+                    className="h-14 w-[72px] shrink-0 rounded bg-muted"
+                  />
+                )}
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="line-clamp-2 text-sm font-medium leading-tight">
+                      {g.name}
+                    </h3>
+                    {g.rating && (
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                        ★ {g.rating}
+                      </span>
+                    )}
+                  </div>
+                  {g.dev && (
+                    <p className="line-clamp-1 text-xs text-muted-foreground">{g.dev}</p>
+                  )}
+                  <div className="flex flex-wrap items-center gap-1 pt-0.5">
+                    {g.genre && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        {g.genre}
+                      </Badge>
+                    )}
+                    {g.status && (
+                      <Badge
+                        variant={g.status === 'Released' ? 'default' : 'outline'}
+                        className="text-[10px]"
+                      >
+                        {g.status}
+                      </Badge>
+                    )}
+                    {g.nsfw === 'Yes' && (
+                      <Badge variant="destructive" className="text-[10px]">
+                        NSFW
+                      </Badge>
+                    )}
+                    {g.safe_virus && g.safe_virus !== '?' && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {g.safe_virus}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            </article>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/webapp/src/components/settings/gpg-card.tsx
+++ b/webapp/src/components/settings/gpg-card.tsx
@@ -1,0 +1,395 @@
+import { useRef, useState, type ChangeEvent } from 'react'
+import { toast } from 'sonner'
+import { KeyRound, Lock, Unlock, Trash2, ShieldCheck, AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import { useAuth } from '@/stores/auth'
+import { useGpg } from '@/stores/gpg'
+import { usePrefs } from '@/stores/prefs'
+import { decryptString, encryptString } from '@/lib/crypto'
+import { readEncryptedGpg, writeEncryptedGpg } from '@/lib/gpg/storage'
+
+function formatFingerprint(fp: string): string {
+  // group every 4 chars
+  return fp.replace(/(.{4})/g, '$1 ').trim()
+}
+
+export function GpgCard() {
+  const pat = useAuth((s) => s.pat)
+  const gpg = useGpg()
+  const prefs = usePrefs()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [armoredInput, setArmoredInput] = useState('')
+  const [gpgPassphrase, setGpgPassphrase] = useState('')
+  const [webappPassphrase, setWebappPassphrase] = useState('')
+  const [unlockPassphrase, setUnlockPassphrase] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  async function handleFileUpload(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const text = await file.text()
+    setArmoredInput(text)
+    e.target.value = ''
+  }
+
+  async function handleImport() {
+    if (!armoredInput.trim()) {
+      toast.error('Paste or upload an armored GPG private key.')
+      return
+    }
+    if (webappPassphrase.length < 8) {
+      toast.error('Confirm your webapp passphrase (min 8 chars) to encrypt the key locally.')
+      return
+    }
+    setBusy(true)
+    try {
+      const { loadPrivateKey, armorPrivateKey } = await import('@/lib/gpg/sign')
+      const { key, fingerprint, uid, emails } = await loadPrivateKey(
+        armoredInput.trim(),
+        gpgPassphrase || null,
+      )
+      // Persist the already-decrypted key wrapped in the webapp's AES-GCM (PAT passphrase).
+      const decryptedArmored = await armorPrivateKey(key)
+      const packed = await encryptString(decryptedArmored, webappPassphrase)
+      writeEncryptedGpg(packed)
+      gpg.setKey(key, fingerprint, uid, emails)
+      gpg.setEnabled(true)
+      // Auto-populate Commit author email with the primary UID so GitHub Verifies on first try.
+      if (!prefs.authorEmail.trim() && emails[0]) {
+        prefs.setAuthorEmail(emails[0])
+      }
+      setArmoredInput('')
+      setGpgPassphrase('')
+      setWebappPassphrase('')
+      toast.success(`Imported ${formatFingerprint(fingerprint)} — signing enabled.`)
+    } catch (err) {
+      toast.error(`Import failed: ${(err as Error).message}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleUnlock() {
+    const packed = readEncryptedGpg()
+    if (!packed) {
+      toast.error('No GPG key stored.')
+      return
+    }
+    if (!unlockPassphrase) {
+      toast.error('Enter your webapp passphrase.')
+      return
+    }
+    setBusy(true)
+    try {
+      const decryptedArmored = await decryptString(packed, unlockPassphrase)
+      const { loadPrivateKey } = await import('@/lib/gpg/sign')
+      // Stored key is already PGP-decrypted; pass null passphrase.
+      const { key, fingerprint, uid, emails } = await loadPrivateKey(decryptedArmored, null)
+      gpg.setKey(key, fingerprint, uid, emails)
+      setUnlockPassphrase('')
+      toast.success(`Signing unlocked (${formatFingerprint(fingerprint)}).`)
+    } catch (err) {
+      toast.error(`Unlock failed: ${(err as Error).message}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function handleLock() {
+    gpg.lock()
+    toast.info('Signing locked. Re-enter your passphrase to unlock.')
+  }
+
+  function handleRemove() {
+    if (!confirm('Remove the encrypted GPG key from this browser? You will need to re-import it.'))
+      return
+    gpg.remove()
+    toast.success('GPG key removed.')
+  }
+
+  async function handleCopyPublic() {
+    if (!gpg.privateKey) return
+    try {
+      const armored = gpg.privateKey.toPublic().armor()
+      await navigator.clipboard.writeText(armored)
+      toast.success(
+        'Public key copied. Paste it into github.com/settings/keys → New GPG key.',
+      )
+    } catch (err) {
+      toast.error(`Copy failed: ${(err as Error).message}`)
+    }
+  }
+
+  async function handleTestSign() {
+    if (!gpg.privateKey) return
+    setBusy(true)
+    try {
+      const { buildCommitObject, currentTzOffsetMin } = await import(
+        '@/lib/gpg/canonicalize'
+      )
+      const { signCommit, verifyDetached } = await import('@/lib/gpg/sign')
+      const canonical = buildCommitObject({
+        tree: '0'.repeat(40),
+        parents: [],
+        author: { name: 'webapp test', email: 'test@local' },
+        committer: { name: 'webapp test', email: 'test@local' },
+        ts: Math.floor(Date.now() / 1000),
+        tzOffsetMin: currentTzOffsetMin(),
+        message: 'webapp signing self-test',
+      })
+      const sig = await signCommit(gpg.privateKey, canonical)
+      const pubArmored = gpg.privateKey.toPublic().armor()
+      const ok = await verifyDetached(pubArmored, canonical, sig)
+      toast[ok ? 'success' : 'error'](
+        ok
+          ? 'Round-trip verified: signing is wired correctly.'
+          : 'Signature failed verification — please re-import the key.',
+      )
+    } catch (err) {
+      toast.error(`Test sign failed: ${(err as Error).message}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <KeyRound className="h-4 w-4" />
+          Commit signing (GPG)
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Sign every commit this app makes so they show as <b>Verified</b> on GitHub. The private
+          key is decrypted once at import and re-encrypted with your webapp passphrase (AES-GCM)
+          before being stored in localStorage — same scheme as the PAT.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="text-sm">
+            Status:{' '}
+            {gpg.privateKey ? (
+              <Badge variant="default">
+                <Unlock className="mr-1 h-3 w-3" /> Unlocked
+              </Badge>
+            ) : gpg.hasStoredGpg ? (
+              <Badge variant="secondary">
+                <Lock className="mr-1 h-3 w-3" /> Saved (locked)
+              </Badge>
+            ) : (
+              <Badge variant="outline">No key imported</Badge>
+            )}
+          </div>
+          {gpg.fingerprint && (
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="outline" className="font-mono text-[10px]">
+                {formatFingerprint(gpg.fingerprint)}
+              </Badge>
+              {gpg.uid && <span className="truncate">{gpg.uid}</span>}
+            </div>
+          )}
+        </div>
+
+        {gpg.emails.length > 0 && (
+          <EmailMatchInfo emails={gpg.emails} authorEmail={prefs.authorEmail} />
+        )}
+
+        {gpg.hasStoredGpg && (
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="gpg-enabled">Sign commits</Label>
+              <p className="text-xs text-muted-foreground">
+                Turn off to keep the key imported but commit unsigned.
+              </p>
+            </div>
+            <Switch
+              id="gpg-enabled"
+              checked={gpg.enabled}
+              onCheckedChange={gpg.setEnabled}
+            />
+          </div>
+        )}
+
+        <Separator />
+
+        {gpg.privateKey ? (
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={handleTestSign} disabled={busy} variant="outline" size="sm">
+              <ShieldCheck className="h-4 w-4" />
+              Test sign
+            </Button>
+            <Button onClick={handleCopyPublic} disabled={busy} variant="outline" size="sm">
+              Copy public key
+            </Button>
+            <Button onClick={handleLock} variant="outline" size="sm">
+              <Lock className="h-4 w-4" />
+              Lock
+            </Button>
+            <Button onClick={handleRemove} variant="destructive" size="sm">
+              <Trash2 className="h-4 w-4" />
+              Remove key
+            </Button>
+          </div>
+        ) : gpg.hasStoredGpg ? (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="gpg-unlock-pass">Webapp passphrase</Label>
+              <Input
+                id="gpg-unlock-pass"
+                type="password"
+                value={unlockPassphrase}
+                onChange={(e) => setUnlockPassphrase(e.target.value)}
+                placeholder="The passphrase that encrypts your PAT"
+                onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={handleUnlock} disabled={busy}>
+                <Unlock className="h-4 w-4" />
+                Unlock
+              </Button>
+              <Button onClick={handleRemove} variant="ghost" size="sm">
+                Remove key
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {!pat && (
+              <p className="text-xs text-muted-foreground">
+                Unlock your PAT first so we can use the same passphrase to encrypt the key.
+              </p>
+            )}
+            <div className="space-y-1.5">
+              <Label htmlFor="gpg-armored">Armored private key</Label>
+              <Textarea
+                id="gpg-armored"
+                rows={6}
+                value={armoredInput}
+                onChange={(e) => setArmoredInput(e.target.value)}
+                placeholder="-----BEGIN PGP PRIVATE KEY BLOCK-----&#10;...&#10;-----END PGP PRIVATE KEY BLOCK-----"
+                className="font-mono text-xs"
+              />
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileRef.current?.click()}
+                  type="button"
+                >
+                  Upload .asc / .key
+                </Button>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept=".asc,.key,.txt"
+                  className="hidden"
+                  onChange={handleFileUpload}
+                />
+                <span className="text-xs text-muted-foreground">
+                  Or paste from <code>gpg --export-secret-keys --armor &lt;key-id&gt;</code>
+                </span>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="gpg-pass">GPG key passphrase</Label>
+              <Input
+                id="gpg-pass"
+                type="password"
+                value={gpgPassphrase}
+                onChange={(e) => setGpgPassphrase(e.target.value)}
+                placeholder="Leave blank if the key has no passphrase"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="gpg-wapp-pass">Webapp passphrase</Label>
+              <Input
+                id="gpg-wapp-pass"
+                type="password"
+                value={webappPassphrase}
+                onChange={(e) => setWebappPassphrase(e.target.value)}
+                placeholder="Same passphrase used for your PAT — min 8 chars"
+              />
+              <p className="text-xs text-muted-foreground">
+                Used to AES-GCM-encrypt the (already-decrypted) key in localStorage.
+              </p>
+            </div>
+            <Button onClick={handleImport} disabled={busy}>
+              <KeyRound className="h-4 w-4" />
+              Import key
+            </Button>
+          </div>
+        )}
+
+        <Separator />
+        <p className="text-xs text-muted-foreground">
+          The public half of this key must be uploaded to{' '}
+          <a
+            href="https://github.com/settings/keys"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            github.com/settings/keys
+          </a>{' '}
+          for the Verified badge to appear. Use <b>Copy public key</b> above (when unlocked) — it
+          puts the armored public block on your clipboard.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmailMatchInfo({
+  emails,
+  authorEmail,
+}: {
+  emails: string[]
+  authorEmail: string
+}) {
+  const trimmed = authorEmail.trim().toLowerCase()
+  const matches = trimmed && emails.some((e) => e.toLowerCase() === trimmed)
+  const noOverride = !trimmed
+  return (
+    <div className="space-y-1.5 rounded-md border bg-muted/30 p-3 text-xs">
+      <div className="font-medium">Key UIDs (one of these must be your commit author email)</div>
+      <div className="flex flex-wrap gap-1">
+        {emails.map((e) => (
+          <Badge
+            key={e}
+            variant={trimmed && e.toLowerCase() === trimmed ? 'default' : 'outline'}
+            className="font-mono text-[10px]"
+          >
+            {e}
+          </Badge>
+        ))}
+      </div>
+      {noOverride ? (
+        <p className="text-muted-foreground">
+          No override set in <b>Commit author</b>. The first UID will be used automatically.
+        </p>
+      ) : matches ? (
+        <p className="text-green-700 dark:text-green-500">
+          ✓ <span className="font-mono">{authorEmail}</span> matches a UID — commits will Verify.
+        </p>
+      ) : (
+        <p className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            <span className="font-mono">{authorEmail}</span> is not in this key's UIDs. GitHub will
+            show <b>"could not be verified"</b> even with a valid signature. Update <b>Commit
+            author</b> above to one of the badges, or clear it to auto-use the primary UID.
+          </span>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/hooks/useDensityEffect.ts
+++ b/webapp/src/hooks/useDensityEffect.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+import { usePrefs } from '@/stores/prefs'
+
+export function useDensityEffect() {
+  const density = usePrefs((s) => s.density)
+  useEffect(() => {
+    document.documentElement.dataset.density = density
+  }, [density])
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -73,3 +73,19 @@
     display: none;
   }
 }
+
+html[data-density='compact'] .density-pad {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+html[data-density='compact'] table {
+  font-size: 0.8125rem;
+}
+html[data-density='compact'] table th,
+html[data-density='compact'] table td {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+html[data-density='compact'] [data-card-pad] {
+  padding: 0.75rem;
+}

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -8,7 +8,7 @@ export interface ThirdParty {
 
 export const APP = {
   name: 'Itch.io Free Games DB',
-  version: '3.2.1',
+  version: '3.3.0',
   repo: 'https://github.com/poli0981/free-games-itchio-list',
   license: 'MIT',
   buildDate: typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : 'dev',
@@ -158,6 +158,7 @@ export const THIRD_PARTY: ThirdParty[] = [
   { name: '@hookform/resolvers', version: '5.2', license: 'MIT', url: 'https://github.com/react-hook-form/resolvers', category: 'data' },
   { name: '@octokit/rest', version: '22.0', license: 'MIT', url: 'https://github.com/octokit/octokit.js', category: 'data' },
   { name: 'idb-keyval', version: '6.2', license: 'Apache-2.0', url: 'https://github.com/jakearchibald/idb-keyval', category: 'data' },
+  { name: 'OpenPGP.js', version: '6.3', license: 'LGPL-3.0', url: 'https://openpgpjs.org', category: 'data' },
 
   // Desktop
   { name: 'Tauri', version: '2.x', license: 'Apache-2.0 OR MIT', url: 'https://tauri.app', category: 'desktop' },

--- a/webapp/src/lib/github/contents.ts
+++ b/webapp/src/lib/github/contents.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest'
 import { PATHS, REPO } from '../config'
+import { atomicCommit } from './git-data'
 import { rebalance } from './data-store'
 import type { Game } from '@/types/game'
 
@@ -22,27 +23,19 @@ export async function readFileWithSha(octokit: Octokit, path: string): Promise<F
   return { content, sha: data.sha }
 }
 
-export async function putFile(
+/**
+ * Single-file commit routed through the Git Data API (so it can be GPG-signed when configured).
+ *
+ * Replaces the older `putFile` which used `PUT /repos/.../contents/{path}`. That endpoint can
+ * never produce a "Verified" commit because GitHub itself authors it from the PAT.
+ */
+export async function commitSingleFile(
   octokit: Octokit,
   path: string,
   content: string,
-  sha: string,
   message: string,
 ): Promise<{ commitSha: string }> {
-  const utf8 = new TextEncoder().encode(content)
-  let binary = ''
-  for (let i = 0; i < utf8.length; i++) binary += String.fromCharCode(utf8[i])
-  const b64 = btoa(binary)
-  const { data } = await octokit.repos.createOrUpdateFileContents({
-    owner: REPO.owner,
-    repo: REPO.name,
-    path,
-    message,
-    content: b64,
-    sha,
-    branch: REPO.branch,
-  })
-  return { commitSha: data.commit.sha ?? '' }
+  return atomicCommit(octokit, [{ path, content }], message)
 }
 
 export interface UpdateGameResult {
@@ -67,7 +60,7 @@ export async function updateGameInChunk(
   const chunkFile = chunks[chunkIndex].name
   const path = PATHS.chunk(chunkFile)
 
-  const { content, sha } = await readFileWithSha(octokit, path)
+  const { content } = await readFileWithSha(octokit, path)
   const remote = JSON.parse(content) as Game[]
   const remoteIdx = remote.findIndex((g) => g.url === url)
   if (remoteIdx === -1) {
@@ -78,6 +71,6 @@ export async function updateGameInChunk(
 
   remote[remoteIdx] = { ...remote[remoteIdx], ...edits }
   const newContent = JSON.stringify(remote, null, 4)
-  const { commitSha } = await putFile(octokit, path, newContent, sha, commitMessage)
+  const { commitSha } = await commitSingleFile(octokit, path, newContent, commitMessage)
   return { commitSha, chunkFile }
 }

--- a/webapp/src/lib/github/git-data.ts
+++ b/webapp/src/lib/github/git-data.ts
@@ -1,6 +1,8 @@
 import type { Octokit } from '@octokit/rest'
 import { PATHS, REPO } from '../config'
 import { rebalance } from './data-store'
+import { buildCommitObject, currentTzOffsetMin, isoFromTs } from '../gpg/canonicalize'
+import { getSignerIfEnabled, type CommitSigner } from './signer'
 import type { Game } from '@/types/game'
 
 export interface FileChange {
@@ -19,8 +21,14 @@ export async function atomicCommit(
   octokit: Octokit,
   changes: FileChange[],
   message: string,
+  signerOverride?: CommitSigner | null,
 ): Promise<{ commitSha: string }> {
   if (changes.length === 0) throw new Error('No changes to commit')
+  // null = caller explicitly opts out of signing; undefined = use default
+  const signer =
+    signerOverride === null
+      ? undefined
+      : signerOverride ?? getSignerIfEnabled()
 
   const { data: refData } = await octokit.git.getRef({
     owner: REPO.owner,
@@ -74,13 +82,39 @@ export async function atomicCommit(
     tree: treeEntries,
   })
 
-  const { data: newCommit } = await octokit.git.createCommit({
+  const createOpts: Parameters<typeof octokit.git.createCommit>[0] = {
     owner: REPO.owner,
     repo: REPO.name,
     message,
     tree: newTree.sha,
     parents: [baseSha],
-  })
+  }
+
+  if (signer) {
+    const ts = Math.floor(Date.now() / 1000)
+    const tzOffsetMin = currentTzOffsetMin()
+    // Normalize message to strip any trailing newlines — GitHub stores commit messages
+    // verbatim (no auto-trailing-newline), so the canonical bytes we sign must match what
+    // GitHub will re-derive from the stored message.
+    const normalizedMessage = message.replace(/\n+$/, '')
+    createOpts.message = normalizedMessage
+    const canonical = buildCommitObject({
+      tree: newTree.sha,
+      parents: [baseSha],
+      author: signer.identity,
+      committer: signer.identity,
+      ts,
+      tzOffsetMin,
+      message: normalizedMessage,
+    })
+    const signature = await signer.sign(canonical)
+    const dateIso = isoFromTs(ts, tzOffsetMin)
+    createOpts.author = { ...signer.identity, date: dateIso }
+    createOpts.committer = { ...signer.identity, date: dateIso }
+    createOpts.signature = signature
+  }
+
+  const { data: newCommit } = await octokit.git.createCommit(createOpts)
 
   await octokit.git.updateRef({
     owner: REPO.owner,

--- a/webapp/src/lib/github/signer.ts
+++ b/webapp/src/lib/github/signer.ts
@@ -1,0 +1,63 @@
+import type { PrivateKey } from 'openpgp'
+import { useAuth } from '@/stores/auth'
+import { useGpg } from '@/stores/gpg'
+import { usePrefs } from '@/stores/prefs'
+
+export interface CommitIdentity {
+  name: string
+  email: string
+}
+
+export interface CommitSigner {
+  identity: CommitIdentity
+  /** Returns an armored detached PGP signature over the canonical commit object string. */
+  sign: (canonical: string) => Promise<string>
+}
+
+/**
+ * Resolve the author/committer identity. Priority:
+ *   1. prefs override (user set name/email in Settings → Commit author)
+ *   2. imported GPG key's primary UID (so signed commits Verify out of the box)
+ *   3. GitHub user
+ *   4. fallback string
+ *
+ * For GPG-signed commits to show as "Verified" on GitHub, the email MUST match a UID in the
+ * uploaded public key — that's why we prefer the GPG key's email over the GitHub noreply.
+ */
+export function resolveCommitIdentity(): CommitIdentity {
+  const prefs = usePrefs.getState()
+  const gpg = useGpg.getState()
+  const user = useAuth.getState().user
+  const gpgEmail = gpg.emails[0] ?? ''
+  const name =
+    prefs.authorName.trim() ||
+    user?.name?.trim() ||
+    user?.login ||
+    'webapp'
+  const email =
+    prefs.authorEmail.trim() ||
+    gpgEmail ||
+    (user ? `${user.login}@users.noreply.github.com` : 'webapp@local')
+  return { name, email }
+}
+
+function makeSigner(privateKey: PrivateKey): CommitSigner {
+  return {
+    identity: resolveCommitIdentity(),
+    sign: async (canonical) => {
+      const { signCommit } = await import('@/lib/gpg/sign')
+      return signCommit(privateKey, canonical)
+    },
+  }
+}
+
+/**
+ * Return a signer iff the user has imported a GPG key, unlocked it, and toggled signing on.
+ * Each commit call site simply does `atomicCommit(o, changes, msg, getSignerIfEnabled())` — or
+ * relies on `atomicCommit`'s default which itself calls this.
+ */
+export function getSignerIfEnabled(): CommitSigner | undefined {
+  const gpg = useGpg.getState()
+  if (!gpg.enabled || !gpg.privateKey) return undefined
+  return makeSigner(gpg.privateKey)
+}

--- a/webapp/src/lib/gpg/canonicalize.ts
+++ b/webapp/src/lib/gpg/canonicalize.ts
@@ -1,0 +1,75 @@
+export interface CommitIdentity {
+  name: string
+  email: string
+}
+
+export interface CommitParts {
+  tree: string
+  parents: string[]
+  author: CommitIdentity
+  committer: CommitIdentity
+  /** Unix timestamp in seconds. Use the same value for both Octokit's `date` and this canonical form. */
+  ts: number
+  /** Minutes east of UTC. Use `-new Date().getTimezoneOffset()` (JS returns minutes west). */
+  tzOffsetMin: number
+  message: string
+}
+
+function fmtTzCompact(offsetMin: number): string {
+  const sign = offsetMin >= 0 ? '+' : '-'
+  const abs = Math.abs(offsetMin)
+  const hh = String(Math.floor(abs / 60)).padStart(2, '0')
+  const mm = String(abs % 60).padStart(2, '0')
+  return `${sign}${hh}${mm}`
+}
+
+function fmtTzColon(offsetMin: number): string {
+  if (offsetMin === 0) return 'Z'
+  const sign = offsetMin >= 0 ? '+' : '-'
+  const abs = Math.abs(offsetMin)
+  const hh = String(Math.floor(abs / 60)).padStart(2, '0')
+  const mm = String(abs % 60).padStart(2, '0')
+  return `${sign}${hh}:${mm}`
+}
+
+export function isoFromTs(ts: number, tzOffsetMin: number): string {
+  const shiftedMs = ts * 1000 + tzOffsetMin * 60 * 1000
+  const iso = new Date(shiftedMs).toISOString().slice(0, 19)
+  return `${iso}${fmtTzColon(tzOffsetMin)}`
+}
+
+/**
+ * Build the canonical Git commit object string for signing.
+ *
+ * Format (no `gpgsig` header — this is the *detached* signing target):
+ *
+ *   tree <sha>\n
+ *   parent <sha>\n   (one line per parent)
+ *   author <name> <<email>> <unix_ts> <±HHMM>\n
+ *   committer <name> <<email>> <unix_ts> <±HHMM>\n
+ *   \n
+ *   <message>
+ *
+ * IMPORTANT: the message portion is used EXACTLY as provided — no trailing newline is added.
+ * GitHub stores the commit message verbatim (observed via `git cat-file -p`: webapp + CI commits
+ * end with the last byte of the message, no trailing \n). Adding \n here would make our signed
+ * canonical differ from GitHub's recomputed canonical, breaking signature verification.
+ *
+ * The caller is responsible for passing the same message string to both this function and
+ * `octokit.git.createCommit({ message })` so the two byte streams match.
+ */
+export function buildCommitObject(p: CommitParts): string {
+  const tz = fmtTzCompact(p.tzOffsetMin)
+  const a = `${p.author.name} <${p.author.email}> ${p.ts} ${tz}`
+  const c = `${p.committer.name} <${p.committer.email}> ${p.ts} ${tz}`
+  const lines = [`tree ${p.tree}`]
+  for (const parent of p.parents) lines.push(`parent ${parent}`)
+  lines.push(`author ${a}`)
+  lines.push(`committer ${c}`)
+  const head = lines.join('\n')
+  return `${head}\n\n${p.message}`
+}
+
+export function currentTzOffsetMin(): number {
+  return -new Date().getTimezoneOffset()
+}

--- a/webapp/src/lib/gpg/sign.ts
+++ b/webapp/src/lib/gpg/sign.ts
@@ -1,0 +1,96 @@
+import type { PrivateKey, Key } from 'openpgp'
+
+type OpenPGP = typeof import('openpgp')
+
+let mod: OpenPGP | null = null
+async function load(): Promise<OpenPGP> {
+  if (!mod) mod = await import('openpgp')
+  return mod
+}
+
+export interface LoadedKey {
+  key: PrivateKey
+  fingerprint: string
+  uid: string
+  /** All UID emails from the key (primary first). For GitHub Verified, author email must match one. */
+  emails: string[]
+}
+
+/**
+ * Parse an armored private key and (if needed) decrypt it with the user-supplied GPG passphrase.
+ *
+ * Returns the decrypted PrivateKey suitable for signing, plus extracted metadata.
+ */
+export async function loadPrivateKey(
+  armored: string,
+  gpgPassphrase: string | null,
+): Promise<LoadedKey> {
+  const openpgp = await load()
+  const raw = await openpgp.readPrivateKey({ armoredKey: armored })
+  const key = raw.isDecrypted()
+    ? raw
+    : await openpgp.decryptKey({ privateKey: raw, passphrase: gpgPassphrase ?? '' })
+  const fingerprint = key.getFingerprint().toUpperCase()
+  const primaryUser = await key.getPrimaryUser()
+  const uid = primaryUser.user.userID?.userID ?? ''
+  const primaryEmail = primaryUser.user.userID?.email ?? ''
+  const otherEmails = key.users
+    .map((u) => u.userID?.email)
+    .filter((e): e is string => !!e && e !== primaryEmail)
+  const emails = primaryEmail ? [primaryEmail, ...otherEmails] : otherEmails
+  return { key, fingerprint, uid, emails }
+}
+
+/**
+ * Re-export an already-decrypted private key in armored form (so we can store it without the
+ * original GPG passphrase wrapper, encrypted instead by the webapp's own AES-GCM passphrase).
+ */
+export async function armorPrivateKey(key: PrivateKey): Promise<string> {
+  return key.armor()
+}
+
+/**
+ * Produce a detached, armored PGP signature over the canonical commit object.
+ *
+ * Signs in BINARY mode (the same mode `gpg --detach-sign --armor` produces). Git/GitHub
+ * verify signatures over the raw bytes of the commit object — using text mode here would
+ * trigger OpenPGP's line-ending normalization and break verification on platforms where
+ * LF/CRLF differ.
+ *
+ * The result is suitable for the `signature` field of GitHub's `POST /repos/.../git/commits`.
+ */
+export async function signCommit(key: PrivateKey, canonical: string): Promise<string> {
+  const openpgp = await load()
+  const binary = new TextEncoder().encode(canonical)
+  const message = await openpgp.createMessage({ binary })
+  const armored = await openpgp.sign({
+    message,
+    signingKeys: key,
+    detached: true,
+    format: 'armored',
+  })
+  return armored as string
+}
+
+/**
+ * Round-trip verification: useful for the Settings "Test sign" button.
+ * Pass the public half (exported via `key.toPublic().armor()`).
+ */
+export async function verifyDetached(
+  publicKeyArmored: string,
+  signedText: string,
+  signatureArmored: string,
+): Promise<boolean> {
+  const openpgp = await load()
+  const publicKey = (await openpgp.readKey({ armoredKey: publicKeyArmored })) as Key
+  const binary = new TextEncoder().encode(signedText)
+  const message = await openpgp.createMessage({ binary })
+  const signature = await openpgp.readSignature({ armoredSignature: signatureArmored })
+  const result = await openpgp.verify({ message, signature, verificationKeys: publicKey })
+  try {
+    await result.signatures[0]?.verified
+    return true
+  } catch {
+    return false
+  }
+}

--- a/webapp/src/lib/gpg/storage.ts
+++ b/webapp/src/lib/gpg/storage.ts
@@ -1,0 +1,64 @@
+const GPG_KEY = 'webapp.gpg.encrypted'
+const GPG_FINGERPRINT_KEY = 'webapp.gpg.fingerprint'
+const GPG_UID_KEY = 'webapp.gpg.uid'
+const GPG_EMAILS_KEY = 'webapp.gpg.emails'
+const GPG_ENABLED_KEY = 'webapp.gpg.enabled'
+
+export interface GpgMetadata {
+  fingerprint: string
+  uid: string
+  emails: string[]
+}
+
+export function readEncryptedGpg(): string | null {
+  return localStorage.getItem(GPG_KEY)
+}
+
+export function writeEncryptedGpg(packed: string): void {
+  localStorage.setItem(GPG_KEY, packed)
+}
+
+export function clearEncryptedGpg(): void {
+  localStorage.removeItem(GPG_KEY)
+  localStorage.removeItem(GPG_FINGERPRINT_KEY)
+  localStorage.removeItem(GPG_UID_KEY)
+  localStorage.removeItem(GPG_EMAILS_KEY)
+  localStorage.removeItem(GPG_ENABLED_KEY)
+}
+
+export function readGpgMetadata(): GpgMetadata | null {
+  const fingerprint = localStorage.getItem(GPG_FINGERPRINT_KEY)
+  const uid = localStorage.getItem(GPG_UID_KEY)
+  if (!fingerprint) return null
+  return { fingerprint, uid: uid ?? '', emails: readEmailsField() }
+}
+
+function readEmailsField(): string[] {
+  const raw = localStorage.getItem(GPG_EMAILS_KEY)
+  // Guard against legacy values written before the field existed (could be the literal
+  // string "undefined" if a previous build did `localStorage.setItem(key, JSON.stringify(undefined))`).
+  if (!raw || raw === 'undefined' || raw === 'null') return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) return parsed.filter((s): s is string => typeof s === 'string')
+  } catch {
+    // fall through
+  }
+  return []
+}
+
+export function writeGpgMetadata(meta: GpgMetadata): void {
+  localStorage.setItem(GPG_FINGERPRINT_KEY, meta.fingerprint)
+  localStorage.setItem(GPG_UID_KEY, meta.uid)
+  localStorage.setItem(GPG_EMAILS_KEY, JSON.stringify(meta.emails ?? []))
+}
+
+export function readGpgEnabled(defaultValue: boolean = true): boolean {
+  const raw = localStorage.getItem(GPG_ENABLED_KEY)
+  if (raw === null) return defaultValue
+  return raw === '1'
+}
+
+export function writeGpgEnabled(value: boolean): void {
+  localStorage.setItem(GPG_ENABLED_KEY, value ? '1' : '0')
+}

--- a/webapp/src/lib/use-is-mobile.ts
+++ b/webapp/src/lib/use-is-mobile.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+const MOBILE_BREAKPOINT_PX = 768
+
+export function useIsMobile(breakpointPx: number = MOBILE_BREAKPOINT_PX): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia(`(max-width: ${breakpointPx - 1}px)`).matches
+  })
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${breakpointPx - 1}px)`)
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [breakpointPx])
+
+  return isMobile
+}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -3,8 +3,8 @@ import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { HashRouter } from 'react-router-dom'
-import { Toaster } from 'sonner'
 import App from './App'
+import { AppToaster } from './components/app-toaster'
 import './index.css'
 
 const queryClient = new QueryClient({
@@ -26,7 +26,7 @@ createRoot(rootEl).render(
       <HashRouter>
         <App />
       </HashRouter>
-      <Toaster richColors position="top-right" />
+      <AppToaster />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </StrictMode>,

--- a/webapp/src/routes/add.tsx
+++ b/webapp/src/routes/add.tsx
@@ -13,7 +13,7 @@ import { useAllGames } from '@/hooks/useGames'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { useAuth } from '@/stores/auth'
 import { createOctokit } from '@/lib/github/client'
-import { putFile, readFileWithSha } from '@/lib/github/contents'
+import { commitSingleFile } from '@/lib/github/contents'
 import {
   dispatchWorkflow,
   findRecentDispatchedRun,
@@ -131,13 +131,11 @@ export default function Add() {
     setProgressMsg(`Writing scripts/temp_link.json with ${valid.length} URLs...`)
     try {
       const octokit = createOctokit()
-      const { sha } = await readFileWithSha(octokit, PATHS.tempLink)
       const newJson = JSON.stringify(valid, null, 4) + '\n'
-      await putFile(
+      await commitSingleFile(
         octokit,
         PATHS.tempLink,
         newJson,
-        sha,
         `chore(webapp): queue ${valid.length} new URLs`,
       )
       setProgressMsg('Dispatching update workflow...')

--- a/webapp/src/routes/charts.tsx
+++ b/webapp/src/routes/charts.tsx
@@ -50,7 +50,7 @@ export default function Charts() {
       <h1 className="mb-4 text-3xl font-bold tracking-tight">Charts</h1>
 
       <Tabs defaultValue="overview">
-        <TabsList>
+        <TabsList className="flex-wrap">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="reach">Reach</TabsTrigger>
           <TabsTrigger value="quality">Quality</TabsTrigger>

--- a/webapp/src/routes/games.tsx
+++ b/webapp/src/routes/games.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DataTable } from '@/components/data-table/data-table'
 import { DataTableToolbar } from '@/components/data-table/data-table-toolbar'
+import { MobileCardList } from '@/components/data-table/mobile-card-list'
 import { gameColumns } from '@/components/data-table/columns'
 import type { FacetOption } from '@/components/data-table/faceted-filter'
 import { BulkEditDialog } from '@/components/bulk-edit-dialog'
@@ -187,6 +188,7 @@ export default function Games() {
         globalFilterFn={gameSearch}
         rowKey={(g) => g.url}
         getRowId={(g) => g.url}
+        renderMobileList={(rows) => <MobileCardList rows={rows} selectable />}
       />
 
       <p className="mt-3 text-xs text-muted-foreground">

--- a/webapp/src/routes/settings.tsx
+++ b/webapp/src/routes/settings.tsx
@@ -1,26 +1,51 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { Lock, Unlock, Trash2, Check, X } from 'lucide-react'
+import { Lock, Unlock, Trash2, Check, X, Sun, Moon, Monitor } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   clearEncryptedPat,
   readEncryptedPat,
   useAuth,
   writeEncryptedPat,
 } from '@/stores/auth'
+import {
+  IDLE_TIMEOUT_OPTIONS,
+  NOTIFICATION_DURATION_OPTIONS,
+  usePrefs,
+} from '@/stores/prefs'
+import { useThemeStore, type Theme } from '@/stores/theme'
 import { decryptString, encryptString } from '@/lib/crypto'
 import { checkRepoAccess, fetchAuthenticatedUser } from '@/lib/github/client'
 import { REPO } from '@/lib/config'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
+import { GpgCard } from '@/components/settings/gpg-card'
+import { cn } from '@/lib/utils'
+
+const THEME_CHOICES: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
 
 export default function Settings() {
   useDocumentTitle('Settings')
   const { pat, user, hasStoredPat, setPat, setUser, lock, refreshStoredFlag } = useAuth()
+  const theme = useThemeStore((s) => s.theme)
+  const setTheme = useThemeStore((s) => s.setTheme)
+  const prefs = usePrefs()
   const [patInput, setPatInput] = useState('')
   const [passphrase, setPassphrase] = useState('')
   const [unlockPassphrase, setUnlockPassphrase] = useState('')
@@ -247,16 +272,171 @@ export default function Settings() {
 
       <Card className="mt-6">
         <CardHeader>
-          <CardTitle className="text-base">Theme</CardTitle>
+          <CardTitle className="text-base">Appearance</CardTitle>
           <p className="text-xs text-muted-foreground">
-            Toggle in the sidebar bottom-left. The choice persists in localStorage and follows
-            your OS in System mode.
+            Theme and layout density. Choices persist to localStorage.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="space-y-2">
+            <Label>Theme</Label>
+            <div className="flex flex-wrap gap-2">
+              {THEME_CHOICES.map(({ value, label, icon: Icon }) => (
+                <Button
+                  key={value}
+                  variant={theme === value ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setTheme(value)}
+                  className={cn('min-w-[88px]')}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="density">Density</Label>
+            <Select
+              value={prefs.density}
+              onValueChange={(v) => prefs.setDensity(v as 'normal' | 'compact')}
+            >
+              <SelectTrigger id="density" className="w-[200px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="normal">Normal</SelectItem>
+                <SelectItem value="compact">Compact (smaller rows)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="sidebar-collapsed">Collapse sidebar</Label>
+              <p className="text-xs text-muted-foreground">
+                Mirror of the toggle in the sidebar footer.
+              </p>
+            </div>
+            <Switch
+              id="sidebar-collapsed"
+              checked={prefs.sidebarCollapsed}
+              onCheckedChange={prefs.setSidebarCollapsed}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Session</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            How long the decrypted PAT stays in memory after unlock.
           </p>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">
-            More appearance options come in Phase 6 polish.
+          <div className="space-y-2">
+            <Label htmlFor="idle">Idle timeout</Label>
+            <Select
+              value={String(prefs.idleTimeoutMs / 60_000)}
+              onValueChange={(v) => prefs.setIdleTimeoutMs(Number(v) * 60_000)}
+            >
+              <SelectTrigger id="idle" className="w-[200px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {IDLE_TIMEOUT_OPTIONS.map((m) => (
+                  <SelectItem key={m} value={String(m)}>
+                    {m < 60 ? `${m} minutes` : `${m / 60} hour${m === 60 ? '' : 's'}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              The PAT auto-locks on idle. Re-enter your passphrase to unlock again.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Commit author</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Optional override for the <span className="font-mono">author</span> and{' '}
+            <span className="font-mono">committer</span> blocks of commits made from this app.
+            Leave blank to use the GitHub user from your PAT.
           </p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="author-name">Name</Label>
+            <Input
+              id="author-name"
+              value={prefs.authorName}
+              onChange={(e) => prefs.setAuthorName(e.target.value)}
+              placeholder={user?.name ?? user?.login ?? 'e.g. Your Name'}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="author-email">Email</Label>
+            <Input
+              id="author-email"
+              type="email"
+              value={prefs.authorEmail}
+              onChange={(e) => prefs.setAuthorEmail(e.target.value)}
+              placeholder={user ? `${user.login}@users.noreply.github.com` : 'you@example.com'}
+            />
+            <p className="text-xs text-muted-foreground">
+              For GPG-signed commits to show as <b>Verified</b>, this email must match one of the
+              UIDs in your GPG key.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <GpgCard />
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Notifications</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Toast notifications shown at the top-right corner.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="notif-enabled">Enable toasts</Label>
+              <p className="text-xs text-muted-foreground">
+                Disables success / error / info popups globally.
+              </p>
+            </div>
+            <Switch
+              id="notif-enabled"
+              checked={prefs.notificationsEnabled}
+              onCheckedChange={prefs.setNotificationsEnabled}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="notif-duration">Duration</Label>
+            <Select
+              value={String(prefs.notificationDurationMs)}
+              onValueChange={(v) => prefs.setNotificationDurationMs(Number(v))}
+            >
+              <SelectTrigger id="notif-duration" className="w-[200px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {NOTIFICATION_DURATION_OPTIONS.map((ms) => (
+                  <SelectItem key={ms} value={String(ms)}>
+                    {ms / 1000}s
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/webapp/src/routes/workflows.tsx
+++ b/webapp/src/routes/workflows.tsx
@@ -6,6 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useAuth } from '@/stores/auth'
 import { createOctokit } from '@/lib/github/client'
 import { dispatchWorkflow, type WorkflowFile, type WorkflowRunSummary } from '@/lib/github/workflow'
@@ -112,11 +119,26 @@ function WorkflowPanel({ file, label, description }: { file: WorkflowFile; label
 
 export default function Workflows() {
   useDocumentTitle('Workflows')
+  const [current, setCurrent] = useState<string>(WORKFLOWS[0].file)
   return (
     <div className="container mx-auto p-6">
       <h1 className="mb-4 text-3xl font-bold tracking-tight">Workflows</h1>
-      <Tabs defaultValue="update.yml">
-        <TabsList className="flex-wrap">
+      <div className="mb-3 md:hidden">
+        <Select value={current} onValueChange={setCurrent}>
+          <SelectTrigger className="h-10 w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {WORKFLOWS.map((w) => (
+              <SelectItem key={w.file} value={w.file}>
+                {w.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Tabs value={current} onValueChange={setCurrent}>
+        <TabsList className="hidden flex-wrap md:inline-flex">
           {WORKFLOWS.map((w) => (
             <TabsTrigger key={w.file} value={w.file}>
               {w.label}

--- a/webapp/src/stores/auth.ts
+++ b/webapp/src/stores/auth.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
+import { usePrefs } from './prefs'
 
 const PAT_STORAGE_KEY = 'webapp.pat.encrypted'
-const IDLE_TIMEOUT_MS = 30 * 60 * 1000
 
 export interface GitHubUserInfo {
   login: string
@@ -34,7 +34,8 @@ export const useAuth = create<AuthState>()((set) => ({
 
 export function isIdleExpired(unlockedAt: number | null): boolean {
   if (unlockedAt === null) return true
-  return Date.now() - unlockedAt > IDLE_TIMEOUT_MS
+  const timeoutMs = usePrefs.getState().idleTimeoutMs
+  return Date.now() - unlockedAt > timeoutMs
 }
 
 export function readEncryptedPat(): string | null {

--- a/webapp/src/stores/gpg.ts
+++ b/webapp/src/stores/gpg.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand'
+import type { PrivateKey } from 'openpgp'
+import {
+  clearEncryptedGpg,
+  readEncryptedGpg,
+  readGpgEnabled,
+  readGpgMetadata,
+  writeGpgEnabled,
+  writeGpgMetadata,
+} from '@/lib/gpg/storage'
+
+interface GpgState {
+  hasStoredGpg: boolean
+  enabled: boolean
+  fingerprint: string | null
+  uid: string | null
+  /** All UID emails from the key, primary first. Persisted so the warning works after reload. */
+  emails: string[]
+  /** In-memory only — cleared on lock or page refresh. */
+  privateKey: PrivateKey | null
+  setKey: (key: PrivateKey, fingerprint: string, uid: string, emails: string[]) => void
+  lock: () => void
+  remove: () => void
+  setEnabled: (v: boolean) => void
+  refreshStoredFlag: () => void
+}
+
+const initialStored = typeof localStorage !== 'undefined' ? !!readEncryptedGpg() : false
+const initialMeta = typeof localStorage !== 'undefined' ? readGpgMetadata() : null
+const initialEnabled = typeof localStorage !== 'undefined' ? readGpgEnabled() : false
+
+export const useGpg = create<GpgState>()((set) => ({
+  hasStoredGpg: initialStored,
+  enabled: initialEnabled,
+  fingerprint: initialMeta?.fingerprint ?? null,
+  uid: initialMeta?.uid ?? null,
+  emails: initialMeta?.emails ?? [],
+  privateKey: null,
+  setKey: (privateKey, fingerprint, uid, emails) => {
+    writeGpgMetadata({ fingerprint, uid, emails })
+    set({ privateKey, fingerprint, uid, emails, hasStoredGpg: true })
+  },
+  lock: () => set({ privateKey: null }),
+  remove: () => {
+    clearEncryptedGpg()
+    set({
+      privateKey: null,
+      hasStoredGpg: false,
+      enabled: false,
+      fingerprint: null,
+      uid: null,
+      emails: [],
+    })
+  },
+  setEnabled: (v) => {
+    writeGpgEnabled(v)
+    set({ enabled: v })
+  },
+  refreshStoredFlag: () => set({ hasStoredGpg: !!readEncryptedGpg() }),
+}))

--- a/webapp/src/stores/prefs.ts
+++ b/webapp/src/stores/prefs.ts
@@ -1,18 +1,51 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+export type Density = 'compact' | 'normal'
+
+export const IDLE_TIMEOUT_OPTIONS = [5, 15, 30, 60, 120] as const
+export type IdleTimeoutMin = (typeof IDLE_TIMEOUT_OPTIONS)[number]
+
+export const NOTIFICATION_DURATION_OPTIONS = [2_000, 4_000, 6_000, 10_000] as const
+
 interface PrefsStore {
   sidebarCollapsed: boolean
+  density: Density
+  notificationsEnabled: boolean
+  notificationDurationMs: number
+  idleTimeoutMs: number
+  authorName: string
+  authorEmail: string
   toggleSidebar: () => void
   setSidebarCollapsed: (v: boolean) => void
+  setDensity: (d: Density) => void
+  setNotificationsEnabled: (v: boolean) => void
+  setNotificationDurationMs: (v: number) => void
+  setIdleTimeoutMs: (v: number) => void
+  setAuthorName: (v: string) => void
+  setAuthorEmail: (v: string) => void
 }
+
+const DEFAULT_IDLE_MS = 30 * 60 * 1000
 
 export const usePrefs = create<PrefsStore>()(
   persist(
     (set) => ({
       sidebarCollapsed: false,
+      density: 'normal',
+      notificationsEnabled: true,
+      notificationDurationMs: 4_000,
+      idleTimeoutMs: DEFAULT_IDLE_MS,
+      authorName: '',
+      authorEmail: '',
       toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
       setSidebarCollapsed: (v) => set({ sidebarCollapsed: v }),
+      setDensity: (d) => set({ density: d }),
+      setNotificationsEnabled: (v) => set({ notificationsEnabled: v }),
+      setNotificationDurationMs: (v) => set({ notificationDurationMs: v }),
+      setIdleTimeoutMs: (v) => set({ idleTimeoutMs: v }),
+      setAuthorName: (v) => set({ authorName: v }),
+      setAuthorEmail: (v) => set({ authorEmail: v }),
     }),
     { name: 'webapp.prefs' },
   ),

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {
+            if (id.includes('openpgp')) return 'vendor-openpgp'
             if (id.includes('recharts') || id.includes('d3-')) return 'vendor-charts'
             if (id.includes('@octokit')) return 'vendor-github'
             if (id.includes('@tanstack')) return 'vendor-query'


### PR DESCRIPTION
## Summary

- **Mobile fix**: card view (`<md:`) for the games table, `<Select>` fallback for the Workflows tabs; iPhone 14 Pro (430x932) no longer overflows horizontally.
- **Settings Phase A**: four new cards — Appearance (theme picker / density / sidebar mirror), Session (idle timeout 5–120 min), Commit author (name/email override), Notifications (toggle + duration). New `density-*` CSS hook and `AppToaster` wrapper applied app-wide.
- **In-browser GPG commit signing**: new `webapp/src/lib/gpg/` module (`canonicalize.ts`, `sign.ts`, `storage.ts`) + `stores/gpg.ts` + `components/settings/gpg-card.tsx`. `openpgp` lazy-loaded into a dedicated `vendor-openpgp` chunk (~129 KB gz). Imported key's UIDs are surfaced as badges; commit author email auto-populates from the primary UID; mismatch warning explains the "Someone may be trying to trick you" failure mode.
- **PUT contents removed**: all write paths now go through the Git Data API so they pick up the signer uniformly. Canonical commit object verified byte-for-byte against `git cat-file commit <sha>`.

Bumped: `README.md`, `README.vi.md`, `webapp/src/lib/about.ts` -> `3.3.0`. New CHANGELOG entry. `docs/ACKNOWLEDGEMENTS.md` lists OpenPGP.js.

Tauri Cargo + tauri.conf.json **not** bumped — front-end-only change, no Rust binary boundary touched.

## Test plan

- [x] Mobile DataTable: 9-col table replaced by card list below `md`, pagination shared.
- [x] Workflows: `<Select>` on mobile, TabsList on desktop, controlled state.
- [x] Settings cards: theme / density / sidebar / idle / author / notifications persist across reload.
- [x] GPG Test sign: round-trip verifies with `openpgp.verify` (binary mode, detached, armored).
- [x] Real-world sign: webapp commit edits show **Verified** badge on github.com with fingerprint matching the imported key.
- [x] TypeScript build clean, Vite production build splits `vendor-openpgp` into a lazy chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)