### PR TITLE
release(v3.4.1): hotfix — DataTable alignment + Discussion-announce auto-discovery

### DIFF
--- a/.github/workflows/announce-discussion.yml
+++ b/.github/workflows/announce-discussion.yml
@@ -6,11 +6,9 @@ name: Announce to Discussion
 # The push job is gated by a `[skip-discuss]` token in the head-commit message
 # so dev can opt out for typo-only commits.
 #
-# Pre-flight (one-time, then hardcode the IDs into the env block below):
-#   gh api graphql -f query='query{repository(owner:"poli0981",name:"free-games-itchio-list"){
-#     id
-#     discussionCategories(first:20){nodes{id slug name}}
-#   }}'
+# No pre-flight needed — repo ID and category IDs are auto-discovered at
+# runtime via GraphQL (by category slug: "announcements" / "general").
+# Requires: GitHub Discussions enabled on the repo with both categories present.
 
 on:
   release:
@@ -51,24 +49,35 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      # TODO(maintainer): replace these placeholders with the real IDs from the
-      # graphql pre-flight query above. Until then this job is intentionally a
-      # no-op (see the validation step).
-      REPO_ID: ${{ vars.DISCUSSION_REPO_ID }}
-      ANNOUNCEMENTS_CATEGORY_ID: ${{ vars.DISCUSSION_ANNOUNCEMENTS_CATEGORY_ID }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Validate IDs are configured
+      - name: Discover Discussion IDs
+        id: ids
         run: |
-          if [ -z "${REPO_ID}" ] || [ -z "${ANNOUNCEMENTS_CATEGORY_ID}" ]; then
-            echo "::warning::DISCUSSION_REPO_ID or DISCUSSION_ANNOUNCEMENTS_CATEGORY_ID not configured as repo variables. Skipping."
-            exit 0
+          set -euo pipefail
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          NAME="${GITHUB_REPOSITORY##*/}"
+          JSON=$(gh api graphql -f owner="$OWNER" -f name="$NAME" -f query='
+            query($owner:String!,$name:String!){
+              repository(owner:$owner,name:$name){
+                id
+                discussionCategories(first:25){nodes{id slug name}}
+              }
+            }')
+          REPO_ID=$(echo "$JSON" | jq -r '.data.repository.id // empty')
+          CAT_ID=$(echo "$JSON" | jq -r '.data.repository.discussionCategories.nodes[] | select(.slug=="announcements") | .id' | head -n1)
+          if [ -z "$REPO_ID" ]; then
+            echo "::error::Could not resolve repository GraphQL ID. Are Discussions enabled on this repo?"
+            exit 1
           fi
-          echo "ids_ok=true" >> "$GITHUB_OUTPUT"
-        id: validate
+          if [ -z "$CAT_ID" ]; then
+            echo "::error::No 'announcements' discussion category found. Create it under Settings → Discussions."
+            exit 1
+          fi
+          echo "repo_id=$REPO_ID" >> "$GITHUB_OUTPUT"
+          echo "category_id=$CAT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Resolve release tag + body
-        if: steps.validate.outputs.ids_ok == 'true'
         id: rel
         env:
           INPUT_TAG: ${{ inputs.tag }}
@@ -95,13 +104,12 @@ jobs:
           echo "title=Release ${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Create Announcements discussion
-        if: steps.validate.outputs.ids_ok == 'true'
         run: |
           set -euo pipefail
           gh api graphql \
             -f query='mutation($r:ID!,$c:ID!,$t:String!,$b:String!){createDiscussion(input:{repositoryId:$r,categoryId:$c,title:$t,body:$b}){discussion{url}}}' \
-            -f r="${REPO_ID}" \
-            -f c="${ANNOUNCEMENTS_CATEGORY_ID}" \
+            -f r="${{ steps.ids.outputs.repo_id }}" \
+            -f c="${{ steps.ids.outputs.category_id }}" \
             -f t="${{ steps.rel.outputs.title }}" \
             -F b=@body.md
 
@@ -113,27 +121,40 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      REPO_ID: ${{ vars.DISCUSSION_REPO_ID }}
-      GENERAL_CATEGORY_ID: ${{ vars.DISCUSSION_GENERAL_CATEGORY_ID }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Validate IDs are configured
-        id: validate
+      - name: Discover Discussion IDs
+        id: ids
         run: |
-          if [ -z "${REPO_ID}" ] || [ -z "${GENERAL_CATEGORY_ID}" ]; then
-            echo "::warning::DISCUSSION_REPO_ID or DISCUSSION_GENERAL_CATEGORY_ID not configured as repo variables. Skipping."
-            exit 0
+          set -euo pipefail
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          NAME="${GITHUB_REPOSITORY##*/}"
+          JSON=$(gh api graphql -f owner="$OWNER" -f name="$NAME" -f query='
+            query($owner:String!,$name:String!){
+              repository(owner:$owner,name:$name){
+                id
+                discussionCategories(first:25){nodes{id slug name}}
+              }
+            }')
+          REPO_ID=$(echo "$JSON" | jq -r '.data.repository.id // empty')
+          CAT_ID=$(echo "$JSON" | jq -r '.data.repository.discussionCategories.nodes[] | select(.slug=="general") | .id' | head -n1)
+          if [ -z "$REPO_ID" ]; then
+            echo "::error::Could not resolve repository GraphQL ID. Are Discussions enabled on this repo?"
+            exit 1
           fi
-          echo "ids_ok=true" >> "$GITHUB_OUTPUT"
+          if [ -z "$CAT_ID" ]; then
+            echo "::error::No 'general' discussion category found. Create it under Settings → Discussions."
+            exit 1
+          fi
+          echo "repo_id=$REPO_ID" >> "$GITHUB_OUTPUT"
+          echo "category_id=$CAT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Checkout (last 2 commits for diff)
-        if: steps.validate.outputs.ids_ok == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
       - name: List changed docs
-        if: steps.validate.outputs.ids_ok == 'true'
         id: changes
         run: |
           set -euo pipefail
@@ -143,7 +164,7 @@ jobs:
           fi
 
       - name: Build body
-        if: steps.validate.outputs.ids_ok == 'true' && steps.changes.outputs.no-docs-changed != 'true'
+        if: steps.changes.outputs.no-docs-changed != 'true'
         id: body
         env:
           MSG: ${{ github.event.head_commit.message }}
@@ -163,12 +184,12 @@ jobs:
           echo "title=Docs update — ${FIRST_LINE} (${SHORT_SHA})" >> "$GITHUB_OUTPUT"
 
       - name: Create General discussion
-        if: steps.validate.outputs.ids_ok == 'true' && steps.changes.outputs.no-docs-changed != 'true'
+        if: steps.changes.outputs.no-docs-changed != 'true'
         run: |
           set -euo pipefail
           gh api graphql \
             -f query='mutation($r:ID!,$c:ID!,$t:String!,$b:String!){createDiscussion(input:{repositoryId:$r,categoryId:$c,title:$t,body:$b}){discussion{url}}}' \
-            -f r="${REPO_ID}" \
-            -f c="${GENERAL_CATEGORY_ID}" \
+            -f r="${{ steps.ids.outputs.repo_id }}" \
+            -f c="${{ steps.ids.outputs.category_id }}" \
             -f t="${{ steps.body.outputs.title }}" \
             -F b=@body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented here.
 
+## [3.4.1] - 2026-05-17 (Hotfix: DataTable column alignment + Discussion-announce auto-discovery)
+
+### Fixed
+
+- **DataTable columns misaligned at desktop widths.** Header used native table-layout (`<table className="w-full">` + `<th style={{width}}>`) while body rows used flex layout (`position: absolute` + `flex w-full`, cells with `flex: 0 0 Npx` / `1 1 0`). Native table-layout stretched the 8 size-less columns to fill the container based on content, but the absolutely-positioned body `<tr>` never participated in table layout — so its flex children stayed at their fixed flex-basis. Result: at the Tauri default 1280×800 window (and any viewport wider than the natural sum of header content widths) header columns drifted off the cells below them. [`webapp/src/components/data-table/data-table.tsx`](webapp/src/components/data-table/data-table.tsx) now renders the header `<tr>` with `flex w-full` and each `<th>` with `flex h-10 items-center` + the same `flex: 0 0 Npx` / `1 1 0` style block as the body `<td>` — header and body now compute width identically. Helper `priorityHeaderClass` (which emitted `table-cell` variants) is gone; the existing `priorityClass` (`flex` variants) now drives both. No change to column definitions in [`columns.tsx`](webapp/src/components/data-table/columns.tsx).
+- **`announce-discussion.yml` was a silent no-op since v3.2.0.** Both jobs (`announce-release`, `announce-docs`) gated on three repo variables (`DISCUSSION_REPO_ID`, `DISCUSSION_ANNOUNCEMENTS_CATEGORY_ID`, `DISCUSSION_GENERAL_CATEGORY_ID`) that had never been configured — the validation step printed `::warning::… Skipping.` and `exit 0`, so every release silently failed to post to Discussions without surfacing a failed run. Replaced the two validation steps with a `Discover Discussion IDs` step that queries `gh api graphql` for `repository.id` and looks up the category by slug (`announcements` / `general`). Zero config now — works on any repo with Discussions enabled. Fails loudly with a clear `::error::` message if Discussions isn't enabled or the expected category is missing. Dropped the dependency on `vars.DISCUSSION_*` and removed every `if: steps.validate.outputs.ids_ok == 'true'` gate.
+
+### Changed
+
+- **README + README.vi badges** bumped to `3.4.1`.
+
+### Notes
+
+- This is a webapp + CI hotfix. No Python pipeline changes, no Tauri / Rust binary boundary change — `Cargo.toml` and `tauri.conf.json` stay at `0.1.1`, no THIRD_PARTY entries change.
+- The leftover `DISCUSSION_REPO_ID` / `DISCUSSION_ANNOUNCEMENTS_CATEGORY_ID` / `DISCUSSION_GENERAL_CATEGORY_ID` repo variables (if you set them earlier) are now unused and can be removed from Settings → Variables.
+
+---
+
 ## [3.4.0] - 2026-05-16 (Periodic refresh workflows + UTF-8 round-trip fix)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.4.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.4.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,6 +1,6 @@
 # Danh sách Game Itch.io Miễn Phí
 
-[![Version](https://img.shields.io/badge/version-3.4.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.4.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md)
 

--- a/webapp/src/components/data-table/data-table.tsx
+++ b/webapp/src/components/data-table/data-table.tsx
@@ -26,12 +26,6 @@ function priorityClass(priority: 1 | 2 | 3 | undefined): string {
   return ''
 }
 
-function priorityHeaderClass(priority: 1 | 2 | 3 | undefined): string {
-  if (priority === 2) return 'hidden md:table-cell'
-  if (priority === 3) return 'hidden lg:table-cell'
-  return ''
-}
-
 interface DataTableProps<TData> {
   data: TData[]
   columns: ColumnDef<TData>[]
@@ -143,15 +137,18 @@ export function DataTable<TData>({
         <table className="w-full text-sm">
           <thead className="sticky top-0 z-10 bg-card shadow-[inset_0_-1px_0_hsl(var(--border))]">
             {headerGroups.map((hg) => (
-              <tr key={hg.id}>
+              <tr key={hg.id} className="flex w-full">
                 {hg.headers.map((h) => (
                   <th
                     key={h.id}
                     className={cn(
-                      'h-10 px-3 text-left align-middle font-medium text-muted-foreground',
-                      priorityHeaderClass(h.column.columnDef.meta?.priority),
+                      'flex h-10 items-center px-3 text-left font-medium text-muted-foreground',
+                      priorityClass(h.column.columnDef.meta?.priority),
                     )}
-                    style={{ width: h.getSize() ? `${h.getSize()}px` : undefined }}
+                    style={{
+                      width: h.getSize() ? `${h.getSize()}px` : undefined,
+                      flex: h.getSize() ? `0 0 ${h.getSize()}px` : '1 1 0',
+                    }}
                   >
                     {h.isPlaceholder
                       ? null

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -8,7 +8,7 @@ export interface ThirdParty {
 
 export const APP = {
   name: 'Itch.io Free Games DB',
-  version: '3.4.0',
+  version: '3.4.1',
   repo: 'https://github.com/poli0981/free-games-itchio-list',
   license: 'MIT',
   buildDate: typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : 'dev',


### PR DESCRIPTION
## Summary

Hotfix release. Two independent fixes:

- **DataTable column alignment at desktop widths.** Header was native table-layout, body was flex; the absolutely-positioned virtual rows never participated in table-layout, so at the Tauri default 1280×800 (and any viewport wider than the natural sum of header content widths) the header columns drifted off the cells below them. Header now uses the same flex layout as the body row — both `<tr>` are `flex w-full` and both cells use the same `flex: 0 0 Npx` / `1 1 0` style block. Drops the `priorityHeaderClass` helper; the existing `priorityClass` now drives both header and body responsive hiding.
- **`announce-discussion.yml` auto-discovers Discussion IDs at runtime.** Both jobs (`announce-release`, `announce-docs`) had been gated on three never-configured repo variables (`DISCUSSION_REPO_ID` + 2 category IDs) — every release since v3.2.0 silently `exit 0`'d in the validation step without flagging a failed run. Replaced the two validation steps with a `Discover Discussion IDs` step that queries `gh api graphql` and looks up categories by slug (`announcements` / `general`). Zero config now; fails loudly if Discussions isn't enabled or a category is missing.

Version-bump scope: `README.md`, `README.vi.md`, `webapp/src/lib/about.ts` (`APP.version`). No Tauri / Rust binary change.

## Test plan

- [x] `npx tsc -b --noEmit` green in `webapp/`.
- [x] Local table render at 1280×800 — header / body cells aligned column-by-column (user-tested on Tauri desktop window).
- [x] Responsive breakpoints — priority-2 columns hide below `md`, priority-3 below `lg` (uses unified `priorityClass`, same logic header + body).
- [ ] Post-merge: trigger `Announce to Discussion` workflow manually with `announce-release` + tag `v3.4.1`. Expect the `Discover Discussion IDs` step to print `repo_id` + `category_id` outputs and the mutation to return `discussion.url`.

Co-Authored-By: Claude Opus 4.7 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)