### PR TITLE
release(v3.5.1): clean up ESLint — zero lint problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented here.
 
+## [3.5.1] - 2026-05-20 (Lint cleanup — zero ESLint problems)
+
+### Changed
+
+- **`npm run lint` now runs clean — 0 errors, 0 warnings** (down from 17 errors + 5 warnings, all pre-existing; v3.5.0 added none).
+  - [`webapp/eslint.config.js`](webapp/eslint.config.js): `react-refresh/only-export-components` is turned off for `src/components/ui/**` — the vendored shadcn primitives intentionally mix component and variant/constant exports and cannot satisfy the rule without forking upstream. The rule stays on for all other app code.
+  - `react-hooks/incompatible-library` is turned off — it only flagged TanStack Table's `useReactTable`, whose API is not React-Compiler-memoizable by design (not actionable).
+- **`SortableHeader` extracted** into its own [`webapp/src/components/data-table/sortable-header.tsx`](webapp/src/components/data-table/sortable-header.tsx); [`columns.tsx`](webapp/src/components/data-table/columns.tsx) is now a pure column-definition module.
+
+### Fixed
+
+- **`react-hooks/exhaustive-deps`** in [`routes/games.tsx`](webapp/src/routes/games.tsx) and [`data-table/faceted-filter.tsx`](webapp/src/components/data-table/faceted-filter.tsx): values built with `?? []` created a fresh array every render, defeating the `useMemo`s that depended on them. `data` is now wrapped in `useMemo`; the faceted-filter `selected` memo was restructured to depend on a stable value.
+
+### Notes
+
+- DX / code-quality only — no runtime behaviour change. No Tauri / Rust binary change (`Cargo.toml` / `tauri.conf.json` stay `0.1.1`); no `THIRD_PARTY` change.
+
+---
+
 ## [3.5.0] - 2026-05-20 (Charts expansion + game-count history + pipeline cleanup)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.5.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.5.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,6 +1,6 @@
 # Danh sách Game Itch.io Miễn Phí
 
-[![Version](https://img.shields.io/badge/version-3.5.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.5.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md)
 

--- a/webapp/eslint.config.js
+++ b/webapp/eslint.config.js
@@ -18,5 +18,18 @@ export default defineConfig([
     languageOptions: {
       globals: globals.browser,
     },
+    rules: {
+      // TanStack Table's useReactTable returns functions that can't be
+      // memoized — the React Compiler warning is not actionable here.
+      'react-hooks/incompatible-library': 'off',
+    },
+  },
+  {
+    // shadcn/ui primitives intentionally mix component and variant/
+    // constant exports; the rule can't be satisfied without forking them.
+    files: ['src/components/ui/**'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
   },
 ])

--- a/webapp/src/components/data-table/columns.tsx
+++ b/webapp/src/components/data-table/columns.tsx
@@ -1,11 +1,10 @@
 import { Link } from 'react-router-dom'
 import type { ColumnDef, FilterFn, RowData } from '@tanstack/react-table'
-import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import type { Game } from '@/types/game'
 import { slugify } from '@/lib/utils'
+import { SortableHeader } from './sortable-header'
 
 declare module '@tanstack/react-table' {
   // priority 1 — always visible. priority 2 — visible at md+. priority 3 — visible at lg+.
@@ -22,27 +21,6 @@ const arrayIncludesAny: FilterFn<Game> = (row, columnId, filterValue) => {
   if (Array.isArray(cell)) return cell.some((v) => filterValue.includes(v))
   if (typeof cell === 'string') return filterValue.includes(cell)
   return false
-}
-
-interface SortableHeaderProps {
-  label: string
-  sorted: false | 'asc' | 'desc'
-  onClick: (e: React.MouseEvent) => void
-}
-
-function SortableHeader({ label, sorted, onClick }: SortableHeaderProps) {
-  return (
-    <Button variant="ghost" size="sm" onClick={onClick} className="-ml-3 h-8">
-      {label}
-      {sorted === 'asc' ? (
-        <ArrowUp className="h-3.5 w-3.5" />
-      ) : sorted === 'desc' ? (
-        <ArrowDown className="h-3.5 w-3.5" />
-      ) : (
-        <ArrowUpDown className="h-3.5 w-3.5 opacity-50" />
-      )}
-    </Button>
-  )
 }
 
 export const gameColumns: ColumnDef<Game>[] = [

--- a/webapp/src/components/data-table/faceted-filter.tsx
+++ b/webapp/src/components/data-table/faceted-filter.tsx
@@ -20,8 +20,8 @@ interface FacetedFilterProps<TData> {
 }
 
 export function FacetedFilter<TData>({ column, title, options }: FacetedFilterProps<TData>) {
-  const filterValue = (column?.getFilterValue() as string[] | undefined) ?? []
-  const selected = useMemo(() => new Set(filterValue), [filterValue])
+  const rawFilterValue = column?.getFilterValue() as string[] | undefined
+  const selected = useMemo(() => new Set(rawFilterValue ?? []), [rawFilterValue])
 
   function toggle(value: string) {
     const next = new Set(selected)

--- a/webapp/src/components/data-table/sortable-header.tsx
+++ b/webapp/src/components/data-table/sortable-header.tsx
@@ -1,0 +1,23 @@
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface SortableHeaderProps {
+  label: string
+  sorted: false | 'asc' | 'desc'
+  onClick: (e: React.MouseEvent) => void
+}
+
+export function SortableHeader({ label, sorted, onClick }: SortableHeaderProps) {
+  return (
+    <Button variant="ghost" size="sm" onClick={onClick} className="-ml-3 h-8">
+      {label}
+      {sorted === 'asc' ? (
+        <ArrowUp className="h-3.5 w-3.5" />
+      ) : sorted === 'desc' ? (
+        <ArrowDown className="h-3.5 w-3.5" />
+      ) : (
+        <ArrowUpDown className="h-3.5 w-3.5 opacity-50" />
+      )}
+    </Button>
+  )
+}

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -8,7 +8,7 @@ export interface ThirdParty {
 
 export const APP = {
   name: 'Itch.io Free Games DB',
-  version: '3.5.0',
+  version: '3.5.1',
   repo: 'https://github.com/poli0981/free-games-itchio-list',
   license: 'MIT',
   buildDate: typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : 'dev',

--- a/webapp/src/routes/games.tsx
+++ b/webapp/src/routes/games.tsx
@@ -51,7 +51,7 @@ export default function Games() {
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
 
-  const data = games.data?.games ?? []
+  const data = useMemo(() => games.data?.games ?? [], [games.data])
 
   const facets = useMemo(() => {
     if (data.length === 0)


### PR DESCRIPTION
## Summary

v3.5.1 — `npm run lint` now runs completely clean (0 errors, 0 warnings; was 17 errors + 5 warnings, all pre-existing — v3.5.0 added none).

- `eslint.config.js`: turn off `react-refresh/only-export-components` for `src/components/ui/**` (vendored shadcn primitives can't satisfy it without forking upstream); turn off `react-hooks/incompatible-library` (non-actionable — TanStack Table's `useReactTable`).
- Extract `SortableHeader` into `data-table/sortable-header.tsx` — `columns.tsx` is now a pure column-definition module.
- Fix `react-hooks/exhaustive-deps` in `games.tsx` and `faceted-filter.tsx` — `?? []` was creating fresh arrays each render, defeating the dependent `useMemo`s.

DX / code-quality only — no runtime behaviour change, no Tauri / Rust binary change (`Cargo.toml` / `tauri.conf.json` stay `0.1.1`).

## Test plan

- [x] `npm run lint` → 0 errors, 0 warnings, exit 0
- [x] `npm run build` (tsc -b + vite) passes
- [x] Dev-server `/games`: table renders, `SortableHeader` sort works (click re-sorts), faceted filters render, 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)