### PR TITLE
release(v3.6.1): pin time 0.3.47 — unbreak desktop builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented here.
 
+## [3.6.1] - 2026-06-12 (Hotfix — desktop build vs broken `time` 0.3.48)
+
+### Fixed
+
+- **v3.6.0's desktop installers never built**: `time` 0.3.48 (released
+  2026-06-12, hours before the v3.6.0 tag) fails to compile inside
+  `tauri-utils` with `E0119: conflicting implementations of trait From<…>`
+  ([time-rs/time#783](https://github.com/time-rs/time/issues/783)). Since no
+  `Cargo.lock` is committed, CI resolved the broken release fresh.
+  `webapp/src-tauri/Cargo.toml` now pins `time = "=0.3.47"` (the version every
+  release through v3.5.2 built with) — remove the pin once the upstream fix
+  ships.
+
+### Notes
+
+- Web feature set is identical to v3.6.0; this tag exists to produce the
+  desktop installers. `about.ts` version bump also busts the new IndexedDB
+  catalog cache, which is harmless.
+- No Tauri version bump (`Cargo.toml` / `tauri.conf.json` stay `0.1.1`) — a
+  dependency pin to the previously-resolved version changes no binary
+  behavior.
+
 ## [3.6.0] - 2026-06-12 (i18n EN/VI + offline cache + custom error pages)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Itch.io Games List
 
-[![Version](https://img.shields.io/badge/version-3.6.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.6.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![Stars](https://img.shields.io/github/stars/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/stargazers)
 [![Forks](https://img.shields.io/github/forks/poli0981/free-games-itchio-list?style=social)](https://github.com/poli0981/free-games-itchio-list/network/members)
 [![Last Updated](https://img.shields.io/github/last-commit/poli0981/free-games-itchio-list?label=last%20updated)](https://github.com/poli0981/free-games-itchio-list/commits/main)

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,6 +1,6 @@
 # Danh sách Game Itch.io Miễn Phí
 
-[![Version](https://img.shields.io/badge/version-3.6.0-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
+[![Version](https://img.shields.io/badge/version-3.6.1-blue.svg)](https://github.com/poli0981/free-games-itchio-list/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md)
 

--- a/webapp/src-tauri/Cargo.toml
+++ b/webapp/src-tauri/Cargo.toml
@@ -21,6 +21,10 @@ tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# time 0.3.48 (2026-06-12) fails to compile via tauri-utils (E0119,
+# https://github.com/time-rs/time/issues/783). No Cargo.lock is committed, so
+# pin the last good version until the upstream fix ships, then remove.
+time = "=0.3.47"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/webapp/src/lib/about.ts
+++ b/webapp/src/lib/about.ts
@@ -8,7 +8,7 @@ export interface ThirdParty {
 
 export const APP = {
   name: 'Itch.io Free Games DB',
-  version: '3.6.0',
+  version: '3.6.1',
   repo: 'https://github.com/poli0981/free-games-itchio-list',
   license: 'MIT',
   buildDate: typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : 'dev',


### PR DESCRIPTION
## What changed

v3.6.0's desktop installers never built: `time` **0.3.48** (released 2026-06-12, hours before the tag) fails to compile inside `tauri-utils` with `E0119: conflicting implementations of trait From<…>` — [time-rs/time#783](https://github.com/time-rs/time/issues/783), fix pending in [#784](https://github.com/time-rs/time/pull/784). Since no `Cargo.lock` is committed, CI resolved the broken release fresh on all 4 platforms.

- Pin `time = "=0.3.47"` in `webapp/src-tauri/Cargo.toml` (the version every release through v3.5.2 built with). Remove the pin once the upstream fix ships.
- Version bump to 3.6.1 (badges, `about.ts`, CHANGELOG). Web feature set identical to v3.6.0; no Tauri version bump (dependency pin = no binary behavior change).

## QA

- `cargo tree -i time` resolves 0.3.47 across the graph; `cargo check` passes locally with the pin.
- `npm run lint` + `npm run build` clean after the `about.ts` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)