### PR TITLE
fix(webapp): stop emitting source maps in the web build

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   build: {
     outDir: isTauri ? 'dist' : '../docs/app',
     emptyOutDir: true,
-    sourcemap: !isTauri,
+    sourcemap: false,
     target: isTauri ? 'es2022' : 'es2020',
     chunkSizeWarningLimit: 600,
     rollupOptions: {


### PR DESCRIPTION
## Problem
The deployed webapp ships JS **source maps**. Opening DevTools → Sources on `poli0981.github.io/free-games-itchio-list/app/` reconstructs the original TypeScript — the source is leaked in the browser.

**Root cause:** `webapp/vite.config.ts` had `sourcemap: !isTauri`. The CI deploy runs `npm run build` with `TAURI_ENV_PLATFORM` unset → `isTauri = false` → `sourcemap = true`, so Vite emits `*.js.map` files into `docs/app/assets/` (uploaded wholesale as the Pages artifact) plus `//# sourceMappingURL=` comments that make DevTools auto-load the sources.

## Fix
`sourcemap: !isTauri` → `sourcemap: false`.

No error-tracking service consumes these maps (`PrivacyPolicy.md` confirms no Sentry/Datadog), so disabling outright is the complete fix — `'hidden'` would still publish fetchable `.map` files. The Tauri build was already mapless; local `npm run dev` sourcemaps are unaffected.

## Cleanup of already-leaked maps
None needed. On merge, `deploy_webapp.yml` rebuilds; `emptyOutDir: true` clears `docs/app/` and the new artifact (no `.map` files) fully replaces the Pages site, purging the previously-published maps.

## Verification
- `npm run build` → **0** `.map` files, **0** `sourceMappingURL` refs in bundles
- `npm run lint` clean
- `npm ci` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)