### PR TITLE
fix(ci): drop gradle cache from Android JDK setup

### DIFF
--- a/.github/workflows/release_android.yml
+++ b/.github/workflows/release_android.yml
@@ -40,7 +40,10 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-          cache: gradle
+          # No `cache: gradle` — the Gradle project lives in gen/android, which
+          # is gitignored and only created later by `tauri android init`, so
+          # there are no gradle files at checkout for setup-java to key on
+          # (it hard-errors otherwise). rust-cache + npm cache still apply.
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
First `release_android.yml` dry-run failed at **Set up JDK** — `actions/setup-java` with `cache: gradle` hard-errors because gen/android (the Gradle project) is gitignored and only generated by `tauri android init` later in the job, so there are no gradle files at checkout to key the cache on. Remove it; rust-cache + npm cache still apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)